### PR TITLE
Edited args in launch.json example file

### DIFF
--- a/docs/ENVIROMENT_CONFIGURATION.md
+++ b/docs/ENVIROMENT_CONFIGURATION.md
@@ -61,9 +61,9 @@ PYTHONPATH=tools/
                 "--environment",
                 "dev",
                 "--use_secrets_manager",
-                "False",
+                "false",
                 "--use_vulnerability_management",
-                "False"
+                "false"
             ],
             "env": {
                 "BUILD_BUILDID": "2688",


### PR DESCRIPTION
## Description

El archivo entry_point_core.py en los argumentos de use_secretes_manager tiene como opciones el 'true' o 'false' y en el launch.json de ejemplo se mapean como 'False', lo cual lleva a un error en la ejecucion de la libreria

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/NU0429001_devsecops_engine/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
