### PR TITLE
fix(command): Update command splitter, add icons and improve some behaviours

### DIFF
--- a/ide_extension/intellij/README.md
+++ b/ide_extension/intellij/README.md
@@ -27,3 +27,18 @@ You can install the plugin from the [JetBrains Plugin Repository](https://plugin
 
 You can have IaC templates with some placeholders that can be replaced by the plugin with values stored on an `.env` file.
 The `.env` file can be generated from values of the Azure DevOps (pipeline, release and stage) variables.
+
+## Known Issues
+
+### Binary not found
+
+When running scans you may encounter the following error:
+
+```
+Error running scan IaC command: java.io.IOException: Cannot run program "docker": error=2, No such file or directory
+	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1143)
+    ...
+```
+
+In this case we recommend you to run the scan after a command that loads your env, for example if you use zsh, you can 
+change the command to `zsh -c "source ~/.zshrc && <scan command here>"`.

--- a/ide_extension/intellij/build.gradle.kts
+++ b/ide_extension/intellij/build.gradle.kts
@@ -101,11 +101,11 @@ intellijPlatform {
         // The pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
         // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
         // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
-//        channels = properties("pluginVersion").map {
-//            listOf(
-//                it.substringAfter('-', "").substringBefore('.').ifEmpty { "default" })
-//        }
-        channels = listOf("beta")
+        channels = properties("pluginVersion").map {
+            listOf(
+                it.substringAfter('-', "").substringBefore('.').ifEmpty { "default" })
+        }
+//        channels = listOf("beta")
     }
 
     pluginVerification {

--- a/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/actions/ScanIacAction.java
+++ b/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/actions/ScanIacAction.java
@@ -37,11 +37,9 @@ public class ScanIacAction extends AnAction {
         Project project = e.getProject();
         LogPanelLogger.activate(project);
         if (project != null) {
-            LogPanelLogger.success("START");
             isTaskRunning = true;
             ScanIacTask task = new ScanIacTask(project, "Scanning iac", () -> isTaskRunning = false);
             ProgressManager.getInstance().run(task);
-            LogPanelLogger.success("END");
         }
     }
 

--- a/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/actions/ScanIacAction.java
+++ b/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/actions/ScanIacAction.java
@@ -2,18 +2,21 @@ package co.com.bancolombia.devsecopsenginetools.actions;
 
 import co.com.bancolombia.devsecopsenginetools.tasks.ScanIacTask;
 import co.com.bancolombia.devsecopsenginetools.ui.tool.LogPanelLogger;
-import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.NlsActions;
+import icons.DevSecOpsIcons;
 import lombok.SneakyThrows;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
 public class ScanIacAction extends AnAction {
+    private boolean isTaskRunning = false;
 
     public ScanIacAction() {
         super();
@@ -25,7 +28,7 @@ public class ScanIacAction extends AnAction {
     }
 
     public static ScanIacAction forUI() {
-        return new ScanIacAction("Scan IaC", "Run iac scan", AllIcons.Actions.Execute);
+        return new ScanIacAction("Scan IaC", "Run iac scan", DevSecOpsIcons.ScanIaC);
     }
 
     @SneakyThrows
@@ -34,8 +37,17 @@ public class ScanIacAction extends AnAction {
         Project project = e.getProject();
         LogPanelLogger.activate(project);
         if (project != null) {
-            ScanIacTask task = new ScanIacTask(project, "Scanning iac");
+            LogPanelLogger.success("START");
+            isTaskRunning = true;
+            ScanIacTask task = new ScanIacTask(project, "Scanning iac", () -> isTaskRunning = false);
             ProgressManager.getInstance().run(task);
+            LogPanelLogger.success("END");
         }
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        Presentation presentation = e.getPresentation();
+        presentation.setEnabled(!isTaskRunning);
     }
 }

--- a/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/actions/ScanImageAction.java
+++ b/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/actions/ScanImageAction.java
@@ -2,18 +2,22 @@ package co.com.bancolombia.devsecopsenginetools.actions;
 
 import co.com.bancolombia.devsecopsenginetools.tasks.ScanImageTask;
 import co.com.bancolombia.devsecopsenginetools.ui.tool.LogPanelLogger;
-import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.NlsActions;
+import icons.DevSecOpsIcons;
 import lombok.SneakyThrows;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
 public class ScanImageAction extends AnAction {
+    private boolean isTaskRunning = false;
+
     public ScanImageAction() {
         super();
     }
@@ -24,7 +28,7 @@ public class ScanImageAction extends AnAction {
     }
 
     public static ScanImageAction forUI() {
-        return new ScanImageAction("Scan Image", "Run image scan", AllIcons.Actions.Rerun);
+        return new ScanImageAction("Scan Image", "Run image scan", DevSecOpsIcons.ScanImage);
     }
 
     @SneakyThrows
@@ -33,8 +37,15 @@ public class ScanImageAction extends AnAction {
         Project project = e.getProject();
         LogPanelLogger.activate(project);
         if (project != null) {
-            ScanImageTask task = new ScanImageTask(project, "Scanning image");
+            isTaskRunning = true;
+            ScanImageTask task = new ScanImageTask(project, "Scanning image", () -> isTaskRunning = false);
             ProgressManager.getInstance().run(task);
         }
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        Presentation presentation = e.getPresentation();
+        presentation.setEnabled(!isTaskRunning);
     }
 }

--- a/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/tasks/Completable.java
+++ b/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/tasks/Completable.java
@@ -1,0 +1,5 @@
+package co.com.bancolombia.devsecopsenginetools.tasks;
+
+public interface Completable {
+    void complete();
+}

--- a/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/tasks/ScanIacTask.java
+++ b/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/tasks/ScanIacTask.java
@@ -24,8 +24,11 @@ import java.util.Map;
 import static java.util.Objects.requireNonNull;
 
 public class ScanIacTask extends Task.Backgroundable {
-    public ScanIacTask(@Nullable Project project, @NlsContexts.ProgressTitle @NotNull String title) {
+    private final Completable completable;
+
+    public ScanIacTask(@Nullable Project project, @NlsContexts.ProgressTitle @NotNull String title, Completable completable) {
         super(project, title, false);
+        this.completable = completable;
     }
 
     @Override
@@ -39,6 +42,7 @@ public class ScanIacTask extends Task.Backgroundable {
         } catch (Exception ex) {
             LogPanelLogger.error("Error running scan IaC command: ", ex);
         }
+        completable.complete();
     }
 
     private @NotNull String getCommand() {

--- a/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/tasks/ScanImageTask.java
+++ b/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/tasks/ScanImageTask.java
@@ -23,8 +23,12 @@ import java.util.Map;
 import static java.util.Objects.requireNonNull;
 
 public class ScanImageTask extends Task.Backgroundable {
-    public ScanImageTask(@Nullable Project project, @NlsContexts.ProgressTitle @NotNull String title) {
+    private final Completable completable;
+
+    public ScanImageTask(@Nullable Project project, @NlsContexts.ProgressTitle @NotNull String title,
+                         Completable completable) {
         super(project, title, false);
+        this.completable = completable;
     }
 
     @Override
@@ -54,6 +58,7 @@ public class ScanImageTask extends Task.Backgroundable {
         } catch (Exception ex) {
             LogPanelLogger.error("Error running scan IaC command: ", ex);
         }
+        completable.complete();
     }
 
     private void prepareFiles(Project project) throws IOException {

--- a/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/ui/configuration/GlobalConfiguration.form
+++ b/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/ui/configuration/GlobalConfiguration.form
@@ -277,16 +277,6 @@
               <grid row="11" column="1" row-span="1" col-span="2" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </hspacer>
-          <component id="f44d7" class="javax.swing.JTextArea" binding="scanImageCommand">
-            <constraints>
-              <grid row="8" column="1" row-span="3" col-span="1" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
-                <preferred-size width="150" height="50"/>
-              </grid>
-            </constraints>
-            <properties>
-              <text value=""/>
-            </properties>
-          </component>
           <component id="4cafd" class="javax.swing.JLabel">
             <constraints>
               <grid row="8" column="0" row-span="3" col-span="1" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false">
@@ -340,6 +330,17 @@
             </constraints>
             <properties>
               <text value="Reset"/>
+            </properties>
+          </component>
+          <component id="6c4e2" class="com.intellij.ui.components.JBTextField" binding="scanImageCommand">
+            <constraints>
+              <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="30"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value=""/>
+              <toolTipText value="Name of the Artifactory project. Used for context to Xray scanning."/>
             </properties>
           </component>
         </children>

--- a/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/ui/configuration/GlobalConfiguration.java
+++ b/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/ui/configuration/GlobalConfiguration.java
@@ -30,7 +30,7 @@ public class GlobalConfiguration implements Configurable, Configurable.NoScroll 
     // Settings
     private JBTextField scanIacCommand;
     private JButton resetIaCButton;
-    private JTextArea scanImageCommand;
+    private JBTextField scanImageCommand;
     private JButton resetImageButton;
     private JBTextField dockerImage;
     private JCheckBox checkForLatestImageCheckBox;

--- a/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/ui/tool/LogPanel.java
+++ b/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/ui/tool/LogPanel.java
@@ -3,6 +3,7 @@ package co.com.bancolombia.devsecopsenginetools.ui.tool;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBPanel;
 import com.intellij.ui.components.JBScrollPane;
+import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 
 import javax.swing.*;
@@ -25,6 +26,7 @@ import java.util.regex.Pattern;
 public class LogPanel extends JBPanel<LogPanel> {
     private final transient StyledDocument doc;
     private final JTextPane textPane;
+    private final JPopupMenu contextMenu;
     private final Map<String, SimpleAttributeSet> ansiCodeToStyle;
 
     public LogPanel() {
@@ -36,6 +38,11 @@ public class LogPanel extends JBPanel<LogPanel> {
         textPane.setContentType("text/html"); // Enable HTML support
         textPane.setBackground(JBColor.WHITE);
         doc = textPane.getStyledDocument();
+
+        contextMenu = new JPopupMenu();
+        JMenuItem clearItem = new JMenuItem("Clear");
+        clearItem.addActionListener(e -> clear());
+        contextMenu.add(clearItem);
 
         ansiCodeToStyle = createAnsiCodeToStyleMap();
 
@@ -51,6 +58,11 @@ public class LogPanel extends JBPanel<LogPanel> {
         } catch (BadLocationException e) {
             log.warn("Error appending text", e);
         }
+    }
+
+    @SneakyThrows
+    private void clear() {
+        doc.remove(0, doc.getLength());
     }
 
     private void parseAndAppend(String log) throws BadLocationException {
@@ -145,6 +157,20 @@ public class LogPanel extends JBPanel<LogPanel> {
             }
         }
 
+        @Override
+        public void mousePressed(MouseEvent e) {
+            if (e.isPopupTrigger()) {
+                showContextMenu(e);
+            }
+        }
+
+        @Override
+        public void mouseReleased(MouseEvent e) {
+            if (e.isPopupTrigger()) {
+                showContextMenu(e);
+            }
+        }
+
         private String getText(Element element) {
             try {
                 return textPane.getDocument().getText(element.getStartOffset(),
@@ -161,6 +187,10 @@ public class LogPanel extends JBPanel<LogPanel> {
             } catch (Exception e) {
                 log.warn("Error opening link: {}", link, e);
             }
+        }
+
+        private void showContextMenu(MouseEvent e) {
+            contextMenu.show(e.getComponent(), e.getX(), e.getY());
         }
     }
 }

--- a/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/utils/Commands.java
+++ b/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/utils/Commands.java
@@ -24,7 +24,7 @@ public class Commands {
     public static void runCommand(String command, Appender appender, ProcessBuilder processBuilder) throws IOException, InterruptedException {
         long start = System.currentTimeMillis();
         for (String current : command.split("\n")) {
-            String[] cmd = current.split(" ");
+            String[] cmd = DataUtils.splitCommand(current);
             processBuilder.command(cmd);
             Process process = processBuilder.start();
             printOutput(appender, process.getInputStream());

--- a/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/utils/DataUtils.java
+++ b/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/utils/DataUtils.java
@@ -6,6 +6,8 @@ import lombok.experimental.UtilityClass;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -67,6 +69,35 @@ public class DataUtils {
                     .replace("%2F", "/");
         }
         return text;
+    }
+
+    public static String[] splitCommand(String command) {
+        List<String> args = new ArrayList<>();
+        StringBuilder currentArg = new StringBuilder();
+        boolean insideQuotes = false;
+
+        for (char c : command.toCharArray()) {
+            if (c == '"' || c == '\'') {
+                insideQuotes = !insideQuotes;
+                if (!insideQuotes && !currentArg.isEmpty()) {
+                    args.add(currentArg.toString());
+                    currentArg.setLength(0);
+                }
+            } else if (c == ' ' && !insideQuotes) {
+                if (!currentArg.isEmpty()) {
+                    args.add(currentArg.toString());
+                    currentArg.setLength(0);
+                }
+            } else {
+                currentArg.append(c);
+            }
+        }
+
+        if (!currentArg.isEmpty()) {
+            args.add(currentArg.toString());
+        }
+
+        return args.toArray(new String[0]);
     }
 
     private static boolean containsEncodedCharacters(String text) {

--- a/ide_extension/intellij/src/main/java/icons/DevSecOpsIcons.java
+++ b/ide_extension/intellij/src/main/java/icons/DevSecOpsIcons.java
@@ -1,0 +1,11 @@
+package icons;
+
+import com.intellij.openapi.util.IconLoader;
+
+import javax.swing.*;
+
+public interface DevSecOpsIcons {
+    Icon ScanIaC = IconLoader.getIcon("/icons/scanIaC.svg", DevSecOpsIcons.class);
+    Icon ScanImage = IconLoader.getIcon("/icons/scanImage.svg", icons.DevSecOpsIcons.class);
+
+}

--- a/ide_extension/intellij/src/main/resources/icons/scanIaC.svg
+++ b/ide_extension/intellij/src/main/resources/icons/scanIaC.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+
+<svg
+   width="17"
+   height="16"
+   viewBox="0 0 17 16"
+   fill="none"
+   version="1.1"
+   id="svg3"
+   sodipodi:docname="scanIaC.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="namedview3"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="14.75"
+     inkscape:cx="8.5084746"
+     inkscape:cy="8"
+     inkscape:window-width="1600"
+     inkscape:window-height="847"
+     inkscape:window-x="51"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3" />
+  <text
+     xml:space="preserve"
+     style="fill:#6c707e;fill-opacity:1;stroke:#6c707e;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+     x="0.4824214"
+     y="11.410156"
+     id="text4-02"><tspan
+       sodipodi:role="line"
+       id="tspan4-3"
+       x="0.4824214"
+       y="11.410156">{</tspan></text>
+  <text
+     xml:space="preserve"
+     style="fill:#6c707e;fill-opacity:1;stroke:#6c707e;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+     x="-16.517578"
+     y="-4.5898442"
+     id="text4-0"
+     transform="scale(-1)"><tspan
+       sodipodi:role="line"
+       id="tspan4-2"
+       x="-16.517578"
+       y="-4.5898442">{</tspan></text>
+  <path
+     fill-rule="evenodd"
+     clip-rule="evenodd"
+     d="M9 9.50215C9 8.32441 10.2951 7.60608 11.2942 8.22967L15.2962 10.7275C16.2372 11.3149 16.2372 12.6851 15.2962 13.2725L11.2942 15.7703C10.2951 16.3939 9 15.6756 9 14.4978V9.50215ZM10.7647 9.07799C10.4317 8.87013 10 9.10957 10 9.50215V14.4978C10 14.8904 10.4317 15.1298 10.7647 14.922L14.7667 12.4241C15.0804 12.2284 15.0804 11.7716 14.7667 11.5758L10.7647 9.07799Z"
+     fill="#208A3C"
+     id="path1" />
+  <path
+     d="M10 9.50217C10 9.10959 10.4317 8.87015 10.7647 9.07801L14.7667 11.5758C15.0804 11.7716 15.0804 12.2284 14.7667 12.4242L10.7647 14.922C10.4317 15.1299 10 14.8904 10 14.4978V9.50217Z"
+     fill="#F2FCF3"
+     id="path2" />
+</svg>

--- a/ide_extension/intellij/src/main/resources/icons/scanIaC_dark.svg
+++ b/ide_extension/intellij/src/main/resources/icons/scanIaC_dark.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+
+<svg
+   width="17"
+   height="16"
+   viewBox="0 0 17 16"
+   fill="none"
+   version="1.1"
+   id="svg3"
+   sodipodi:docname="scanIaC_dark.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="namedview3"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="14.75"
+     inkscape:cx="8.5084746"
+     inkscape:cy="8"
+     inkscape:window-width="1600"
+     inkscape:window-height="847"
+     inkscape:window-x="51"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3" />
+  <text
+     xml:space="preserve"
+     style="fill:#ced0d6;fill-opacity:1;stroke:#ced0d6;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+     x="0.48632812"
+     y="11.410156"
+     id="text4"><tspan
+       sodipodi:role="line"
+       id="tspan4"
+       x="0.48632812"
+       y="11.410156">{</tspan></text>
+  <text
+     xml:space="preserve"
+     style="fill:#ced0d6;fill-opacity:1;stroke:#ced0d6;stroke-width:1;stroke-dasharray:none;stroke-opacity:1"
+     x="-16.521484"
+     y="-4.5898438"
+     id="text4-0"
+     transform="scale(-1)"><tspan
+       sodipodi:role="line"
+       id="tspan4-2"
+       x="-16.521484"
+       y="-4.5898438">{</tspan></text>
+  <path
+     fill-rule="evenodd"
+     clip-rule="evenodd"
+     d="M9 9.50215C9 8.32441 10.2951 7.60608 11.2942 8.22967L15.2962 10.7275C16.2372 11.3149 16.2372 12.6851 15.2962 13.2725L11.2942 15.7703C10.2951 16.3939 9 15.6756 9 14.4978V9.50215ZM10.7647 9.07799C10.4317 8.87013 10 9.10957 10 9.50215V14.4978C10 14.8904 10.4317 15.1298 10.7647 14.922L14.7667 12.4241C15.0804 12.2284 15.0804 11.7716 14.7667 11.5758L10.7647 9.07799Z"
+     fill="#57965C"
+     id="path1" />
+  <path
+     d="M10 9.50217C10 9.10959 10.4317 8.87015 10.7647 9.07801L14.7667 11.5758C15.0804 11.7716 15.0804 12.2284 14.7667 12.4242L10.7647 14.922C10.4317 15.1299 10 14.8904 10 14.4978V9.50217Z"
+     fill="#253627"
+     id="path2" />
+  <text
+     xml:space="preserve"
+     style="fill:#ced0d6;fill-opacity:1;stroke:#57965c"
+     x="-8.6101694"
+     y="9.2881355"
+     id="text3"><tspan
+       sodipodi:role="line"
+       id="tspan3"
+       x="-8.6101694"
+       y="9.2881355" /></text>
+</svg>

--- a/ide_extension/intellij/src/main/resources/icons/scanImage.svg
+++ b/ide_extension/intellij/src/main/resources/icons/scanImage.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+
+<svg
+   width="17"
+   height="16"
+   viewBox="0 0 17 16"
+   fill="none"
+   version="1.1"
+   id="svg3"
+   sodipodi:docname="scanImage.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="namedview3"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="30.318842"
+     inkscape:cx="10.867829"
+     inkscape:cy="7.0253344"
+     inkscape:window-width="1600"
+     inkscape:window-height="847"
+     inkscape:window-x="51"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3" />
+  <g
+     id="g1"
+     transform="translate(-0.5000003,2)">
+    <rect
+       style="fill:#6c707e;stroke:#6c707e;stroke-width:1.03552"
+       id="rect1"
+       width="1.9644796"
+       height="1.9644798"
+       x="2.0177603"
+       y="7.5177598" />
+    <rect
+       style="fill:#6c707e;stroke:#6c707e;stroke-width:1.03552"
+       id="rect1-7"
+       width="1.9644796"
+       height="1.9644798"
+       x="6.0177598"
+       y="7.5177598" />
+    <rect
+       style="fill:#6c707e;stroke:#6c707e;stroke-width:1.03552"
+       id="rect1-7-3"
+       width="1.9644796"
+       height="1.9644798"
+       x="14.01776"
+       y="7.5177598" />
+    <rect
+       style="fill:#6c707e;stroke:#6c707e;stroke-width:1.03552"
+       id="rect1-7-3-1"
+       width="1.9644796"
+       height="1.9644798"
+       x="10.01776"
+       y="7.5177598" />
+    <rect
+       style="fill:#6c707e;stroke:#6c707e;stroke-width:1.03552"
+       id="rect1-7-3-9"
+       width="1.9644796"
+       height="1.9644798"
+       x="10.01776"
+       y="3.51776" />
+    <rect
+       style="fill:#6c707e;stroke:#6c707e;stroke-width:1.03552"
+       id="rect1-7-3-1-5"
+       width="1.9644796"
+       height="1.9644798"
+       x="6.0177598"
+       y="3.51776" />
+    <rect
+       style="fill:#6c707e;stroke:#6c707e;stroke-width:1.03552"
+       id="rect1-7-3-4"
+       width="1.9644796"
+       height="1.9644798"
+       x="10.01776"
+       y="-0.48224002" />
+  </g>
+  <path
+     fill-rule="evenodd"
+     clip-rule="evenodd"
+     d="M9 9.50215C9 8.32441 10.2951 7.60608 11.2942 8.22967L15.2962 10.7275C16.2372 11.3149 16.2372 12.6851 15.2962 13.2725L11.2942 15.7703C10.2951 16.3939 9 15.6756 9 14.4978V9.50215ZM10.7647 9.07799C10.4317 8.87013 10 9.10957 10 9.50215V14.4978C10 14.8904 10.4317 15.1298 10.7647 14.922L14.7667 12.4241C15.0804 12.2284 15.0804 11.7716 14.7667 11.5758L10.7647 9.07799Z"
+     fill="#208A3C"
+     id="path1" />
+  <path
+     d="M10 9.50217C10 9.10959 10.4317 8.87015 10.7647 9.07801L14.7667 11.5758C15.0804 11.7716 15.0804 12.2284 14.7667 12.4242L10.7647 14.922C10.4317 15.1299 10 14.8904 10 14.4978V9.50217Z"
+     fill="#F2FCF3"
+     id="path2" />
+  <rect
+     style="fill:#6c707e;stroke:#6c707e;stroke-width:1.03552"
+     id="rect1-7-3-7"
+     width="1.9644796"
+     height="1.9644798"
+     x="19.517759"
+     y="-3.4822402" />
+</svg>

--- a/ide_extension/intellij/src/main/resources/icons/scanImage_dark.svg
+++ b/ide_extension/intellij/src/main/resources/icons/scanImage_dark.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+
+<svg
+   width="17"
+   height="16"
+   viewBox="0 0 17 16"
+   fill="none"
+   version="1.1"
+   id="svg3"
+   sodipodi:docname="scanImage_dark.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="namedview3"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="14.75"
+     inkscape:cx="8.5084746"
+     inkscape:cy="8"
+     inkscape:window-width="1600"
+     inkscape:window-height="847"
+     inkscape:window-x="51"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3" />
+  <g
+     id="g1">
+    <rect
+       style="fill:#ced0d6;stroke:#ced0d6;stroke-width:1.03552;fill-opacity:1;stroke-opacity:1"
+       id="rect1"
+       width="1.9644796"
+       height="1.9644798"
+       x="1.5177602"
+       y="9.5177593" />
+    <rect
+       style="fill:#ced0d6;stroke:#ced0d6;stroke-width:1.03552;fill-opacity:1;stroke-opacity:1"
+       id="rect1-7"
+       width="1.9644796"
+       height="1.9644798"
+       x="5.5177598"
+       y="9.5177593" />
+    <rect
+       style="fill:#ced0d6;stroke:#ced0d6;stroke-width:1.03552;fill-opacity:1;stroke-opacity:1"
+       id="rect1-7-3"
+       width="1.9644796"
+       height="1.9644798"
+       x="13.51776"
+       y="9.5177593" />
+    <rect
+       style="fill:#ced0d6;stroke:#ced0d6;stroke-width:1.03552;fill-opacity:1;stroke-opacity:1"
+       id="rect1-7-3-1"
+       width="1.9644796"
+       height="1.9644798"
+       x="9.5177603"
+       y="9.5177593" />
+    <rect
+       style="fill:#ced0d6;stroke:#ced0d6;stroke-width:1.03552;fill-opacity:1;stroke-opacity:1"
+       id="rect1-7-3-9"
+       width="1.9644796"
+       height="1.9644798"
+       x="9.5177603"
+       y="5.5177603" />
+    <rect
+       style="fill:#ced0d6;stroke:#ced0d6;stroke-width:1.03552;fill-opacity:1;stroke-opacity:1"
+       id="rect1-7-3-1-5"
+       width="1.9644796"
+       height="1.9644798"
+       x="5.5177598"
+       y="5.5177603" />
+    <rect
+       style="fill:#ced0d6;stroke:#ced0d6;stroke-width:1.03552;fill-opacity:1;stroke-opacity:1"
+       id="rect1-7-3-4"
+       width="1.9644796"
+       height="1.9644798"
+       x="9.5177603"
+       y="1.51776" />
+  </g>
+  <path
+     fill-rule="evenodd"
+     clip-rule="evenodd"
+     d="M9 9.50215C9 8.32441 10.2951 7.60608 11.2942 8.22967L15.2962 10.7275C16.2372 11.3149 16.2372 12.6851 15.2962 13.2725L11.2942 15.7703C10.2951 16.3939 9 15.6756 9 14.4978V9.50215ZM10.7647 9.07799C10.4317 8.87013 10 9.10957 10 9.50215V14.4978C10 14.8904 10.4317 15.1298 10.7647 14.922L14.7667 12.4241C15.0804 12.2284 15.0804 11.7716 14.7667 11.5758L10.7647 9.07799Z"
+     fill="#57965C"
+     id="path1" />
+  <path
+     d="M10 9.50217C10 9.10959 10.4317 8.87015 10.7647 9.07801L14.7667 11.5758C15.0804 11.7716 15.0804 12.2284 14.7667 12.4242L10.7647 14.922C10.4317 15.1299 10 14.8904 10 14.4978V9.50217Z"
+     fill="#253627"
+     id="path2" />
+  <text
+     xml:space="preserve"
+     style="fill:#ced0d6;fill-opacity:1;stroke:#57965c"
+     x="-8.6101694"
+     y="9.2881355"
+     id="text3"><tspan
+       sodipodi:role="line"
+       id="tspan3"
+       x="-8.6101694"
+       y="9.2881355" /></text>
+</svg>

--- a/ide_extension/intellij/src/test/java/co/com/bancolombia/devsecopsenginetools/utils/DataUtilsTest.java
+++ b/ide_extension/intellij/src/test/java/co/com/bancolombia/devsecopsenginetools/utils/DataUtilsTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 
@@ -64,5 +65,15 @@ public class DataUtilsTest {
         String result = DataUtils.urlEncode(value);
         // Assert
         assertEquals("Group%2FName", result);
+    }
+
+    @Test
+    public void shouldSplitCommand() {
+        // Arrange
+        String value = "zsh -c 'echo sample && echo another'";
+        // Act
+        String[] result = DataUtils.splitCommand(value);
+        // Assert
+        assertArrayEquals(new String[]{"zsh", "-c", "echo sample && echo another"}, result);
     }
 }


### PR DESCRIPTION
## Description

### Fix
Update command splitter because it does not allow custom sh runner, add icons and improve some behaviours

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
