### PR TITLE
refactor(engine_dependencies): update xray manager scan

### DIFF
--- a/example_remote_config_local/engine_sca/engine_dependencies/ConfigTool.json
+++ b/example_remote_config_local/engine_sca/engine_dependencies/ConfigTool.json
@@ -1,6 +1,6 @@
 {
     "XRAY": {
-        "CLI_VERSION": "2.52.8",
+        "CLI_VERSION": "2.55.0",
         "REGEX_EXPRESSION_EXTENSIONS": "\\.(jar|ear|war)$",
         "PACKAGES_TO_SCAN": ["node_modules", "site-packages"]
     },

--- a/tools/devsecops_engine_tools/engine_sca/engine_dependencies/src/infrastructure/driven_adapters/xray_tool/xray_manager_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_dependencies/src/infrastructure/driven_adapters/xray_tool/xray_manager_scan.py
@@ -204,7 +204,7 @@ class XrayScan(ToolGateway):
         result = subprocess.run(
             command, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
         )
-        if result.returncode == 0:
+        if result.stdout:
             scan_result = json.loads(result.stdout)
             file_result = os.path.join(os.getcwd(), "scan_result.json")
             with open(file_result, "w") as file:

--- a/tools/devsecops_engine_tools/engine_sca/engine_dependencies/test/infrastructure/driven_adapters/xray_tool/test_xray_manager_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_dependencies/test/infrastructure/driven_adapters/xray_tool/test_xray_manager_scan.py
@@ -348,7 +348,7 @@ def test_scan_dependencies_failure(xray_scan_instance):
         mode = "scan"
         to_scan = "target_file.tar"
         mock_subprocess_run.return_value = Mock(
-            returncode=1, stderr="Command 'xray scan' returned non-zero exit status 1."
+            returncode=1, stderr="Command 'xray scan' returned non-zero exit status 1.", stdout=""
         )
 
         xray_scan_instance.scan_dependencies(prefix, cwd, mode, to_scan)

--- a/tools/devsecops_engine_tools/version.py
+++ b/tools/devsecops_engine_tools/version.py
@@ -1,1 +1,1 @@
-version = '1.8.5'
+version = '1.8.3'

--- a/tools/devsecops_engine_tools/version.py
+++ b/tools/devsecops_engine_tools/version.py
@@ -1,1 +1,1 @@
-version = '1.8.3'
+version = '1.8.6'


### PR DESCRIPTION
## Description

Change to xray manager scan, in order to handle when jfrog cli return code is different from 0, but the tool report was successfully generated.

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
