### PR TITLE
fix(actuator_rule): adjust call to run_trufflehog

### DIFF
--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/src/infrastructure/driven_adapters/trufflehog/trufflehog_run.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/src/infrastructure/driven_adapters/trufflehog/trufflehog_run.py
@@ -82,7 +82,7 @@ class TrufflehogRun(ToolGateway):
                 [exclude_path] * len(include_paths),
                 include_paths,
                 [repository_name] * len(include_paths),
-                [enable_custom_rules],
+                [enable_custom_rules] * len(include_paths),
             )
         findings, file_findings = self.create_file(self.decode_output(results), agent_work_folder)
         return  findings, file_findings


### PR DESCRIPTION
 adjust call to run_trufflehog to send parameter in all threads

### Fix
 adjust call to run_trufflehog to send parameter in all threads

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
