### PR TITLE
fix(spring_actuator):  enable custom rules set to false if secret are None

### DIFF
--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/src/infrastructure/driven_adapters/trufflehog/trufflehog_run.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/src/infrastructure/driven_adapters/trufflehog/trufflehog_run.py
@@ -72,7 +72,7 @@ class TrufflehogRun(ToolGateway):
         if enable_custom_rules == "true" and secret is not None:
             self.configurate_external_checks(config_tool, secret)
         else: #In case that remote config from tool is enable but in the args dont send any type of secrets. So dont modified command
-            enable_custom_rules == "false"
+            enable_custom_rules = "false"
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=config_tool.number_threads) as executor:
             results = executor.map(

--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/src/infrastructure/driven_adapters/trufflehog/trufflehog_run.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/src/infrastructure/driven_adapters/trufflehog/trufflehog_run.py
@@ -65,7 +65,7 @@ class TrufflehogRun(ToolGateway):
         secret = None
         
         if secret_tool is not None:
-            secret = secret_tool["github_token"] if "github" in secret_tool else None
+            secret = secret_tool["github_token"] if "github_token" in secret_tool else None
         elif secret_external_checks is not None:
             secret = secret_external_checks.split("github:")[1] if "github" in secret_external_checks else None            
 


### PR DESCRIPTION
 enable custom rules set to false if secret are None

### Fix
Bad asignation for variable enable_custom_rule

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
