### PR TITLE
fix(report_sonar): use get secrets method of driven adapter

### DIFF
--- a/tools/devsecops_engine_tools/engine_utilities/sonarqube/src/domain/usecases/report_sonar.py
+++ b/tools/devsecops_engine_tools/engine_utilities/sonarqube/src/domain/usecases/report_sonar.py
@@ -87,7 +87,7 @@ class ReportSonar:
             scan_type = "SONARQUBE",
             input_core = input_core,
             dict_args = args,
-            secret_tool = self.secrets_manager_gateway,
+            secret_tool = self.secrets_manager_gateway.get_secret(config_tool),
             config_tool = config_tool,
             source_code_management_uri = source_code_management_uri,
             base_compact_remote_config_url = compact_remote_config_url,

--- a/tools/devsecops_engine_tools/engine_utilities/sonarqube/src/domain/usecases/report_sonar.py
+++ b/tools/devsecops_engine_tools/engine_utilities/sonarqube/src/domain/usecases/report_sonar.py
@@ -66,8 +66,10 @@ class ReportSonar:
         
         if args["use_secrets_manager"] == "true": 
             secret = self.secrets_manager_gateway.get_secret(config_tool)
+            secret_tool = secret
         else: 
             secret = args
+            secret_tool = None
 
         report_config_tool = self.devops_platform_gateway.get_remote_config(
             args["remote_config_repo"],
@@ -87,7 +89,7 @@ class ReportSonar:
             scan_type = "SONARQUBE",
             input_core = input_core,
             dict_args = args,
-            secret_tool = self.secrets_manager_gateway.get_secret(config_tool),
+            secret_tool = secret_tool,
             config_tool = config_tool,
             source_code_management_uri = source_code_management_uri,
             base_compact_remote_config_url = compact_remote_config_url,


### PR DESCRIPTION
### Fix
Use get secrets method of driven adapter instead all secrets manager gateway object

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
