### PR TITLE
fix(report_sonar): secret tool in get all VM method

### DIFF
--- a/tools/devsecops_engine_tools/engine_utilities/sonarqube/src/domain/usecases/report_sonar.py
+++ b/tools/devsecops_engine_tools/engine_utilities/sonarqube/src/domain/usecases/report_sonar.py
@@ -106,7 +106,7 @@ class ReportSonar:
                 findings = self.vulnerability_management_gateway.get_all(
                     service=project_key,
                     dict_args=args,
-                    secret_tool=self.secrets_manager_gateway,
+                    secret_tool=secret_tool,
                     config_tool=config_tool
                 )[0]
                 filtered_findings = self.sonar_gateway.filter_by_sonarqube_tag(findings)


### PR DESCRIPTION
### Fix
Send secret_tool secrets when secrets manager is activated in get all vulnerability management method

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
