### PR TITLE
fix(report_sonar): use branch tag instead branch name

### DIFF
--- a/tools/devsecops_engine_tools/engine_utilities/sonarqube/src/domain/usecases/report_sonar.py
+++ b/tools/devsecops_engine_tools/engine_utilities/sonarqube/src/domain/usecases/report_sonar.py
@@ -42,7 +42,7 @@ class ReportSonar:
 
     def process(self, args):
         pipeline_name = self.devops_platform_gateway.get_variable("pipeline_name")
-        branch = self.devops_platform_gateway.get_variable("branch_name")
+        branch = self.devops_platform_gateway.get_variable("branch_tag").replace("refs/heads/", "")
         input_core = InputCore(
             [],
             {},


### PR DESCRIPTION
### Fix
Use branch tag instead branch name to obtain the full branch name including folders, to avoid inconsistencies between the branches
 
## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
