### PR TITLE
fix(xray): verify architecture of machine

### DIFF
--- a/tools/devsecops_engine_tools/engine_sca/engine_dependencies/src/infrastructure/driven_adapters/xray_tool/xray_manager_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_dependencies/src/infrastructure/driven_adapters/xray_tool/xray_manager_scan.py
@@ -29,7 +29,11 @@ class XrayScan(ToolGateway):
         if installed.returncode == 1:
             command = ["chmod", "+x", prefix]
             try:
-                url = f"https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/{version}/jfrog-cli-linux-amd64/jf"
+                architecture = platform.machine()
+                if architecture == "aarch64":
+                    url = f"https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/{version}/jfrog-cli-linux-arm64/jf"
+                else:
+                    url = f"https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/{version}/jfrog-cli-linux-amd64/jf"
                 response = requests.get(url, allow_redirects=True)
                 with open(prefix, "wb") as archivo:
                     archivo.write(response.content)


### PR DESCRIPTION
### Fix
Verify architecture of machine to download the appropriate jfrog cli

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
