### PR TITLE
fix(engine_secret): download custom rules if enabled

### DIFF
--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/src/infrastructure/driven_adapters/trufflehog/trufflehog_run.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/src/infrastructure/driven_adapters/trufflehog/trufflehog_run.py
@@ -72,7 +72,8 @@ class TrufflehogRun(ToolGateway):
         exclude_path = f"{agent_work_folder}/excludedPath.txt"
         include_paths = self.config_include_path(files_commits, agent_work_folder, agent_os)
         enable_custom_rules = config_tool[tool]["ENABLE_CUSTOM_RULES"]
-        Utils().configurate_external_checks(tool, config_tool, secret_tool, secret_external_checks, agent_work_folder)
+        if enable_custom_rules:
+            Utils().configurate_external_checks(tool, config_tool, secret_tool, secret_external_checks, agent_work_folder)
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=config_tool[tool]["NUMBER_THREADS"]) as executor:
             results = executor.map(


### PR DESCRIPTION
## Description

fix(engine_secret): download custom rules if enabled in remote_config repository

### Fix
*How does someone fix the issue in code and/or in runtime?* No

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
