### PR TITLE
fix: remove acces-key

### DIFF
--- a/example_remote_config_local/engine_sca/engine_container/ConfigTool.json
+++ b/example_remote_config_local/engine_sca/engine_container/ConfigTool.json
@@ -2,7 +2,6 @@
     "PRISMA_CLOUD": {
         "TWISTCLI_PATH": "twistcli",
         "PRISMA_CONSOLE_URL": "",
-        "PRISMA_ACCESS_KEY": "",
         "PRISMA_API_VERSION":"",
         "SBOM_FORMAT": "cyclonedx_json"
     },

--- a/tools/devsecops_engine_tools/engine_core/src/applications/runner_engine_core.py
+++ b/tools/devsecops_engine_tools/engine_core/src/applications/runner_engine_core.py
@@ -146,7 +146,7 @@ def get_inputs_from_cli(args):
     parser.add_argument(
         "--token_engine_container",
         required=False,
-        help="Token to execute engine_container if is necessary",
+        help="Token to execute engine_container if is necessary, accesskey:secretkey",
     )
     parser.add_argument(
         "--token_engine_dependencies",

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/src/infrastructure/driven_adapters/prisma_cloud/prisma_cloud_manager_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/src/infrastructure/driven_adapters/prisma_cloud/prisma_cloud_manager_scan.py
@@ -21,14 +21,13 @@ class PrismaCloudManagerScan(ToolGateway):
     def download_twistcli(
         self,
         file_path,
-        prisma_access_key,
-        prisma_secret_key,
+        prisma_key,
         prisma_console_url,
         prisma_api_version,
     ):
         url = f"{prisma_console_url}/api/{prisma_api_version}/util/twistcli"
         credentials = base64.b64encode(
-            f"{prisma_access_key}:{prisma_secret_key}".encode()
+            prisma_key.encode()
         ).decode()
         headers = {"Authorization": f"Basic {credentials}"}
         try:
@@ -46,7 +45,7 @@ class PrismaCloudManagerScan(ToolGateway):
             raise ValueError(f"Error downloading twistcli: {e}")
 
     def scan_image(
-        self, file_path, image_name, result_file, remoteconfig, prisma_secret_key
+        self, file_path, image_name, result_file, remoteconfig, prisma_key
     ):
         command = (
             file_path,
@@ -55,9 +54,9 @@ class PrismaCloudManagerScan(ToolGateway):
             "--address",
             remoteconfig["PRISMA_CLOUD"]["PRISMA_CONSOLE_URL"],
             "--user",
-            remoteconfig["PRISMA_CLOUD"]["PRISMA_ACCESS_KEY"],
+            self._split_prisma_token(prisma_key)[0],
             "--password",
-            prisma_secret_key,
+            self._split_prisma_token(prisma_key)[1],
             "--output-file",
             result_file,
             "--details",
@@ -100,11 +99,11 @@ class PrismaCloudManagerScan(ToolGateway):
         except subprocess.CalledProcessError as e:
              logger.error(f"Error during write image base of {base_image}: {e.stderr}")
             
-    def _generate_sbom(self, image_scanned, remoteconfig, prisma_secret_key, image_name):
+    def _generate_sbom(self, image_scanned, remoteconfig, prisma_key, image_name):
 
         url = f"{remoteconfig['PRISMA_CLOUD']['PRISMA_CONSOLE_URL']}/api/{remoteconfig['PRISMA_CLOUD']['PRISMA_API_VERSION']}/sbom/download/cli-images"
         credentials = base64.b64encode(
-            f"{remoteconfig['PRISMA_CLOUD']['PRISMA_ACCESS_KEY']}:{prisma_secret_key}".encode()
+            prisma_key.encode()
         ).decode()
         headers = {"Authorization": f"Basic {credentials}"}
         try:
@@ -137,11 +136,19 @@ class PrismaCloudManagerScan(ToolGateway):
         except Exception as e:
             logger.error(f"Error generating SBOM: {e}")
 
+
+    def _split_prisma_token(self, prisma_key):
+        try:
+            access_prisma, token_prisma = prisma_key.split(":")
+            return access_prisma, token_prisma
+        except ValueError:
+            raise ValueError("The string is not properly formatted. Make sure it contains a ':'.")
+        
     def run_tool_container_sca(
         self, remoteconfig, secret_tool, token_engine_container, image_name, result_file, base_image, exclusions, generate_sbom
     ):
-        prisma_secret_key = (
-            secret_tool["token_prisma_cloud"] if secret_tool else token_engine_container
+        prisma_key = (
+            f"{secret_tool['access_prisma']}:{secret_tool['token_prisma']}" if secret_tool else token_engine_container
         )
         file_path = os.path.join(
             os.getcwd(), remoteconfig["PRISMA_CLOUD"]["TWISTCLI_PATH"]
@@ -151,8 +158,7 @@ class PrismaCloudManagerScan(ToolGateway):
         if not os.path.exists(file_path):
             self.download_twistcli(
                 file_path,
-                remoteconfig["PRISMA_CLOUD"]["PRISMA_ACCESS_KEY"],
-                prisma_secret_key,
+                prisma_key,
                 remoteconfig["PRISMA_CLOUD"]["PRISMA_CONSOLE_URL"],
                 remoteconfig["PRISMA_CLOUD"]["PRISMA_API_VERSION"],
             )
@@ -161,7 +167,7 @@ class PrismaCloudManagerScan(ToolGateway):
             image_name,
             result_file,
             remoteconfig,
-            prisma_secret_key
+            prisma_key
         )
         if base_image:
             self._write_image_base(result_file, base_image, exclusions)
@@ -169,7 +175,7 @@ class PrismaCloudManagerScan(ToolGateway):
             sbom_components = self._generate_sbom(
                 image_scanned,
                 remoteconfig,
-                prisma_secret_key,
+                prisma_key,
                 image_name
             )
 

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/test/infrastructure/driven_adapters/prisma_cloud/test_prisma_cloud_manager_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/test/infrastructure/driven_adapters/prisma_cloud/test_prisma_cloud_manager_scan.py
@@ -64,8 +64,7 @@ def test_download_twistcli_success(mock_remoteconfig):
         scan_manager = PrismaCloudManagerScan()
         scan_manager.download_twistcli(
             "file_path",
-            "prisma_access_key",
-            "prisma_secret_key",
+            "prisma_key",
             mock_remoteconfig["PRISMA_CLOUD"]["PRISMA_CONSOLE_URL"],
             mock_remoteconfig["PRISMA_CLOUD"]["PRISMA_API_VERSION"],
         )
@@ -73,8 +72,7 @@ def test_download_twistcli_success(mock_remoteconfig):
 
 def test_download_twistcli_failure(twistcli_instance, mock_requests_get):
     file_path = "/path/to/twistcli"
-    prisma_access_key = "your_access_key"
-    prisma_secret_key = "your_secret_key"
+    prisma_key = "your_access_key:your_secret_key"
     prisma_console_url = "https://prisma-console-url.com"
     prisma_api_version = "v1"
 
@@ -95,8 +93,7 @@ def test_download_twistcli_failure(twistcli_instance, mock_requests_get):
     ) as mock_logger_info:
         twistcli_instance.download_twistcli(
             file_path,
-            prisma_access_key,
-            prisma_secret_key,
+            prisma_key,
             prisma_console_url,
             prisma_api_version,
         )
@@ -131,7 +128,7 @@ def test_scan_image_success(mock_remoteconfig):
             "image_name",
             "result.json",
             mock_remoteconfig,
-            "prisma_secret_key"
+            "prisma_access_key:some_secret_key",
         )
 
        
@@ -144,9 +141,9 @@ def test_scan_image_success(mock_remoteconfig):
                 "--address",
                 mock_remoteconfig["PRISMA_CLOUD"]["PRISMA_CONSOLE_URL"],
                 "--user",
-                mock_remoteconfig["PRISMA_CLOUD"]["PRISMA_ACCESS_KEY"],
+                "prisma_access_key",
                 "--password",
-                "prisma_secret_key",
+                "some_secret_key",
                 "--output-file",
                 "result.json",
                 "--details",
@@ -173,7 +170,7 @@ def test_run_tool_container_sca_success(mock_remoteconfig, mock_scan_image):
         scan_manager = PrismaCloudManagerScan()
         result = scan_manager.run_tool_container_sca(
             mock_remoteconfig,
-            {"token_prisma_cloud": "token"},
+            {"access_prisma": "asdasd","token_prisma": "asdasd"},
             "token_container",
             "image_name",
             "result.json" , None , {"exclusions": "all"},
@@ -203,22 +200,21 @@ def test_generate_sbom_success():
             "PRISMA_CLOUD": {
                 "PRISMA_CONSOLE_URL": "http://example.com",
                 "PRISMA_API_VERSION": "v1",
-                "PRISMA_ACCESS_KEY": "access_key",
                 "SBOM_FORMAT": "json",
             }
         }
-        prisma_secret_key = "secret_key"
+        prisma_key = "secret_key"
         image_name = "test_image"
 
         # Llamar a la función
         result = prisma_scan._generate_sbom(
-            image_scanned, remoteconfig, prisma_secret_key, image_name
+            image_scanned, remoteconfig, prisma_key, image_name
         )
 
         # Verificar que se llamaron las funciones esperadas
         mock_request.assert_called_once_with(
             "http://example.com/api/v1/sbom/download/cli-images",
-            headers={"Authorization": "Basic YWNjZXNzX2tleTpzZWNyZXRfa2V5"},
+            headers={"Authorization": "Basic c2VjcmV0X2tleQ=="},
             params={"id": "12345", "sbomFormat": "json"},
         )
         assert result is not None
@@ -297,3 +293,29 @@ def test_write_image_base_file_not_found():
         scan_manager = PrismaCloudManagerScan()
         with pytest.raises(FileNotFoundError):
             scan_manager._write_image_base("result.json", "python:3.9", exclusions_data)
+
+def test_valid_prisma_key():
+    scan_manager = PrismaCloudManagerScan()
+    prisma_key = "your_access_key:your_secret_key"
+    result = scan_manager._split_prisma_token(prisma_key)
+    assert result == ("your_access_key", "your_secret_key")
+    assert type(result) == tuple
+
+def test_invalid_prisma_key():
+    scan_manager = PrismaCloudManagerScan()
+    prisma_key = "your_access_key"
+    with pytest.raises(ValueError, match="The string is not properly formatted. Make sure it contains a ':'."):
+        scan_manager._split_prisma_token(prisma_key)
+
+def test_empty_prisma_key():
+    scan_manager = PrismaCloudManagerScan()
+    prisma_key = ""
+    with pytest.raises(ValueError, match="The string is not properly formatted. Make sure it contains a ':'."):
+        scan_manager._split_prisma_token(prisma_key)
+
+def test_extra_colon_prisma_key():
+    scan_manager = PrismaCloudManagerScan()
+    prisma_key = "your_access_key:your_secret_key:extra"
+    with pytest.raises(ValueError, match="The string is not properly formatted. Make sure it contains a ':'."):
+        scan_manager._split_prisma_token(prisma_key)
+    


### PR DESCRIPTION

### Fix
Remove from access-key from remote config avoiding hacker numbering

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
