### PR TITLE
fix(defect_dojo): certificate verification is disabled

### DIFF
--- a/tools/devsecops_engine_tools/engine_utilities/defect_dojo/infraestructure/driver_adapters/product_type.py
+++ b/tools/devsecops_engine_tools/engine_utilities/defect_dojo/infraestructure/driver_adapters/product_type.py
@@ -22,7 +22,7 @@ class ProductTypeRestConsumer:
         data = json.dumps({"name": product_type_name})
         headers = {"Authorization": f"Token {self.__token}", "Content-Type": "application/json"}
         try:
-            response = self.__session.post(url, headers=headers, data=data)
+            response = self.__session.post(url, headers=headers, data=data, verify=VERIFY_CERTIFICATE)
             if response.status_code != 201:
                 raise ApiError(response.json())
             product_type_object = ProductType.from_dict(response.json())


### PR DESCRIPTION
### Fix
Certificate verification is disabled in the product type post

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
