### PR TITLE
fix(secret): folder path flag

### DIFF
--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/src/domain/model/gateway/tool_gateway.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/src/domain/model/gateway/tool_gateway.py
@@ -14,5 +14,6 @@ class ToolGateway(metaclass=ABCMeta):
                             secret_tool,
                             secret_external_checks,
                             agent_tem_dir:str,
-                            tool) -> str:
+                            tool,
+                            folder_path) -> str:
         "run tool secret scan"

--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/src/domain/usecases/secret_scan.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/src/domain/usecases/secret_scan.py
@@ -54,7 +54,8 @@ class SecretScan:
                     secret_tool,
                     secret_external_checks,
                     self.devops_platform_gateway.get_variable("temp_directory"),
-                    tool)
+                    tool,
+                    dict_args["folder_path"])
             finding_list = self.tool_deserialize.get_list_vulnerability(
                 findings,
                 self.devops_platform_gateway.get_variable("os"),

--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/src/infrastructure/driven_adapters/gitleaks/gitleaks_tool.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/src/infrastructure/driven_adapters/gitleaks/gitleaks_tool.py
@@ -92,7 +92,8 @@ class GitleaksTool(ToolGateway):
         secret_tool,  # For external checks
         secret_external_checks,  # For external checks
         agent_temp_dir,
-        tool
+        tool,
+        folder_path = None
     ):
         command = [self._COMMAND, "dir"]
         finding_path = os.path.join(agent_work_folder, "gitleaks_report.json")

--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/src/infrastructure/driven_adapters/trufflehog/trufflehog_run.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/src/infrastructure/driven_adapters/trufflehog/trufflehog_run.py
@@ -62,7 +62,8 @@ class TrufflehogRun(ToolGateway):
         secret_tool,
         secret_external_checks,
         agent_temp_dir,
-        tool
+        tool,
+        folder_path
     ):
         trufflehog_command = "trufflehog"
         if "Windows" in agent_os:
@@ -84,7 +85,8 @@ class TrufflehogRun(ToolGateway):
                 include_paths,
                 [repository_name] * len(include_paths),
                 [enable_custom_rules] * len(include_paths),
-                [agent_os] * len(include_paths)
+                [agent_os] * len(include_paths),
+                [folder_path] * len(include_paths)
             )
         findings, file_findings = self.create_file(self.decode_output(results), agent_work_folder, config_tool, tool)
         return  findings, file_findings
@@ -117,10 +119,11 @@ class TrufflehogRun(ToolGateway):
         include_path,
         repository_name,
         enable_custom_rules,
-        agent_os
+        agent_os,
+        folder_path
     ):
-        command = f"{trufflehog_command} filesystem {agent_work_folder + '/' + repository_name} --include-paths {include_path} --exclude-paths {exclude_path} --no-verification --no-update --json"
-
+        path = agent_work_folder if folder_path is not None else f"{agent_work_folder}/{repository_name}"
+        command = f"{trufflehog_command} filesystem {path} --include-paths {include_path} --exclude-paths {exclude_path} --no-verification --no-update --json"
         if enable_custom_rules:
             command = command.replace("--no-verification --no-update --json", f"--config {agent_work_folder}//rules//trufflehog//custom-rules.yaml --no-verification --no-update --json" if "Windows" in agent_os else
                                       "/tmp/rules/trufflehog/custom-rules.yaml --no-verification --no-update --json" if "Linux" in agent_os else

--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/test/infrastructure/driven_adapters/trufflehog/test_trufflehog_run.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/test/infrastructure/driven_adapters/trufflehog/test_trufflehog_run.py
@@ -134,7 +134,17 @@ class TestTrufflehogRun(unittest.TestCase):
 
         trufflehog_run = TrufflehogRun()
 
-        result, file_findings = trufflehog_run.run_tool_secret_scan(files_commits, agent_os, agent_work_folder, repository_name, json_config_tool, secret_tool, secret_external_checks, agent_temp_dir, "trufflehog")
+        result, file_findings = trufflehog_run.run_tool_secret_scan(
+            files_commits,
+            agent_os,
+            agent_work_folder,
+            repository_name,
+            json_config_tool,
+            secret_tool,
+            secret_external_checks,
+            agent_temp_dir,
+            "trufflehog",
+            "/")
 
         expected_result = [
             {"SourceMetadata": {"Data": {"Filesystem": {"file": "/usr/bin/local/file1.txt", "line": 1}}}, "SourceID": 1,
@@ -165,7 +175,7 @@ class TestTrufflehogRun(unittest.TestCase):
         enable_custom_rules = False
         trufflehog_run = TrufflehogRun()
 
-        result = trufflehog_run.run_trufflehog('trufflehog', '/usr/local', '/usr/temp/excludedPath.txt', '/usr/temp/includePath0.txt', 'NU00000_Repo_Test', enable_custom_rules, "trufflehog")
+        result = trufflehog_run.run_trufflehog('trufflehog', '/usr/local', '/usr/temp/excludedPath.txt', '/usr/temp/includePath0.txt', 'NU00000_Repo_Test', enable_custom_rules, "trufflehog", "/")
 
         expected_result = '{"SourceMetadata":{"Data":{"Filesystem":{"file":"/usr/bin/local/file1.txt","line":1}}},"SourceID":1,"SourceType":15,"SourceName":"trufflehog - filesystem","DetectorType":17,"DetectorName":"URI","DecoderName":"BASE64","Verified":false,"Raw":"https://admin:admin@the-internet.herokuapp.com","RawV2":"https://admin:admin@the-internet.herokuapp.com/basic_auth","Redacted":"https://admin:********@the-internet.herokuapp.com","ExtraData":null,"StructuredData":null}'
         self.assertEqual(result, expected_result)
@@ -176,7 +186,7 @@ class TestTrufflehogRun(unittest.TestCase):
         enable_custom_rules = True
         trufflehog_run = TrufflehogRun()
 
-        result = trufflehog_run.run_trufflehog('trufflehog', '/usr/local', '/usr/temp/excludedPath.txt', '/usr/temp/includePath0.txt', 'NU00000_Repo_Test', enable_custom_rules, "trufflehog")
+        result = trufflehog_run.run_trufflehog('trufflehog', '/usr/local', '/usr/temp/excludedPath.txt', '/usr/temp/includePath0.txt', 'NU00000_Repo_Test', enable_custom_rules, "trufflehog", "/")
 
         expected_result = '{"SourceMetadata":{"Data":{"Filesystem":{"file":"/usr/bin/local/file1.txt","line":1}}},"SourceID":1,"SourceType":15,"SourceName":"trufflehog - filesystem","DetectorType":17,"DetectorName":"URI","DecoderName":"BASE64","Verified":false,"Raw":"https://admin:admin@the-internet.herokuapp.com","RawV2":"https://admin:admin@the-internet.herokuapp.com/basic_auth","Redacted":"https://admin:********@the-internet.herokuapp.com","ExtraData":null,"StructuredData":null}'
         self.assertEqual(result, expected_result)


### PR DESCRIPTION
## Description

Fix use of folder path flag to engine secret

### Fix
*How does someone fix the issue in code and/or in runtime?* yes

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
