### PR TITLE
fix(remote_config_generator): remove comments from tsconfigs json to …

### DIFF
--- a/remote_config_generator/config-tool-generator/tsconfig.app.json
+++ b/remote_config_generator/config-tool-generator/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {

--- a/remote_config_generator/config-tool-generator/tsconfig.json
+++ b/remote_config_generator/config-tool-generator/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
   "compileOnSave": false,
   "compilerOptions": {

--- a/remote_config_generator/config-tool-generator/tsconfig.spec.json
+++ b/remote_config_generator/config-tool-generator/tsconfig.spec.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {


### PR DESCRIPTION
…make them parseable

## Description

* This change make posible to parse the tsconfig files so they can be analized by tools, currently some tools failed due to failed parsing errors. Comments are not intended be part of json files on formats like //.. or /**....**/ based on json definition [RFC 4627](http://www.ietf.org/rfc/rfc4627.txt)

### Fix
* Removing commented first line on tsconfig .json files

## Checklist:

- [ ] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
