### PR TITLE
fix(prisma): Adjustment to install twistcli

### DIFF
--- a/tools/devsecops_engine_tools/engine_sca/engine_container/src/infrastructure/driven_adapters/prisma_cloud/prisma_cloud_manager_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/src/infrastructure/driven_adapters/prisma_cloud/prisma_cloud_manager_scan.py
@@ -5,6 +5,7 @@ import subprocess
 import logging
 import base64
 import json
+import platform
 from devsecops_engine_tools.engine_sca.engine_container.src.domain.model.gateways.tool_gateway import (
     ToolGateway,
 )
@@ -25,7 +26,25 @@ class PrismaCloudManagerScan(ToolGateway):
         prisma_console_url,
         prisma_api_version,
     ):
-        url = f"{prisma_console_url}/api/{prisma_api_version}/util/twistcli"
+        
+        machine = platform.machine()
+        system = platform.system()
+
+        base_url = f"{prisma_console_url}/api/{prisma_api_version}/util"
+
+        os_mapping = {
+            "Linux": "twistcli",
+            "Windows": "windows/twistcli.exe",
+            "Darwin": "osx/twistcli",
+        }
+
+        url = f"{base_url}/{os_mapping[system]}"
+
+        if system == "Linux" and machine == "aarch64":
+            url = f"{base_url}/arm64/twistcli"
+        elif system == "Darwin" and machine == "aarch64":
+            url = f"{base_url}/osx/arm64/twistcli"
+
         credentials = base64.b64encode(
             prisma_key.encode()
         ).decode()


### PR DESCRIPTION
Adjustment to install twistcli according to the operating system and architecture

## Description

The possible operating systems running the DevSecOps Engine Tools are taken into account to download the corresponding CLI considering their architecture. The following documentation was considered: https://pan.dev/compute/api/get-util-arm-64-twistcli/

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
