### PR TITLE
fix: A new source code management URI is added

### DIFF
--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/azure/azure_devops.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/azure/azure_devops.py
@@ -65,6 +65,10 @@ class AzureDevops(DevopsPlatformGateway):
             "github": (
                 f"https://github.com/{BuildVariables.Build_Repository_Name.value()}"
             ),
+            "git": (
+                f"{SystemVariables.System_TeamFoundationCollectionUri.value()}"
+                f"{SystemVariables.System_TeamProject.value()}/_git/{BuildVariables.Build_Repository_Name.value()}"
+            ).replace(" ", "%20")
         }
         return source_code_management_uri.get(BuildVariables.Build_Repository_Provider.value().lower())
 

--- a/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/serializers/import_scan.py
+++ b/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/serializers/import_scan.py
@@ -179,7 +179,7 @@ class ImportScanSerializer(Schema):
     product_name = fields.Str(required=False)
     engagement_name = fields.Str(required=True)
     engagement_end_date = fields.Str(required=False)
-    source_code_management_uri = fields.Str(required=False)
+    source_code_management_uri = fields.Str(required=False, load_default=None)
     engagement = fields.Int(required=False)
     auto_create_context = fields.Str(required=False, load_default="true")
     deduplication_on_engagement = fields.Str(required=False)


### PR DESCRIPTION
A new source code management URI is added, and the serialization of the import scan is adjusted

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
