### PR TITLE
fix(prisma): Parameterize format of the Prisma scan result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ twistcli
 trivy*
 trivy_*
 *scan_result.json
+*scan_result.csv
 jf
 jf.exe
 target

--- a/example_remote_config_local/engine_sca/engine_container/ConfigTool.json
+++ b/example_remote_config_local/engine_sca/engine_container/ConfigTool.json
@@ -23,6 +23,7 @@
     },
     "MESSAGE_INFO_ENGINE_CONTAINER": "message custom",
     "IGNORE_SEARCH_PATTERN":"(.*_demo0|.*_cer)",
+    "FORMAT_RESULT": "json|csv",
     "THRESHOLD": {
         "VULNERABILITY": {
             "Critical": 4,

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/src/domain/usecases/container_sca_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/src/domain/usecases/container_sca_scan.py
@@ -111,7 +111,7 @@ class ContainerScaScan:
         )
         if matching_image:
             image_name = matching_image.tags[0]
-            result_file = image_name.replace("/", "_") + "_scan_result.json"
+            result_file = image_name.replace("/", "_") + "_scan_result.csv"
             if image_name in self.get_images_already_scanned():
                 print(f"The image {image_name} has already been scanned previously.")
                 return image_scanned, base_image, sbom_components

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/src/domain/usecases/container_sca_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/src/domain/usecases/container_sca_scan.py
@@ -111,7 +111,7 @@ class ContainerScaScan:
         )
         if matching_image:
             image_name = matching_image.tags[0]
-            result_file = image_name.replace("/", "_") + "_scan_result.csv"
+            result_file = image_name.replace("/", "_") + f'_scan_result.{self.remote_config["FORMAT_RESULT"]}'
             if image_name in self.get_images_already_scanned():
                 print(f"The image {image_name} has already been scanned previously.")
                 return image_scanned, base_image, sbom_components

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/test/domain/usescases/test_container_sca_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/test/domain/usescases/test_container_sca_scan.py
@@ -102,6 +102,12 @@ def test_process_image_not_already_scanned(container_sca_scan):
     container_sca_scan.get_base_image = MagicMock(return_value="base_image:latest")
     container_sca_scan.get_images_already_scanned = MagicMock(return_value=[])
     container_sca_scan.tool_run = MagicMock()
+    container_sca_scan.remote_config = {
+        "FORMAT_RESULT": "csv",
+        "SBOM": {"ENABLED": False, "BRANCH_FILTER": []},
+        "GET_IMAGE_BASE": True,
+        "VALIDATE_BASE_IMAGE_DATE": {"ENABLED": False},
+    }
     component_list = [
         Component("component1", "version1"),
         Component("component2", "version2"),

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/test/domain/usescases/test_container_sca_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/test/domain/usescases/test_container_sca_scan.py
@@ -67,7 +67,7 @@ def test_get_images_already_scanned(container_sca_scan):
 
 def test_set_image_scanned(container_sca_scan):
     with patch("builtins.open") as mock_open:
-        container_sca_scan.set_image_scanned("result.json")
+        container_sca_scan.set_image_scanned("result.csv")
         assert mock_open.call_count == 1
 
 
@@ -107,14 +107,14 @@ def test_process_image_not_already_scanned(container_sca_scan):
         Component("component2", "version2"),
     ]
     container_sca_scan.tool_run.run_tool_container_sca.return_value = (
-        "my_image:1234_scan_result.json",
+        "my_image:1234_scan_result.csv",
         component_list,
     )
     container_sca_scan.set_image_scanned = MagicMock()
 
     image_scanned, base_image, components = container_sca_scan.process()
 
-    assert image_scanned == "my_image:1234_scan_result.json"
+    assert image_scanned == "my_image:1234_scan_result.csv"
     container_sca_scan.get_image.assert_called_once_with(
         container_sca_scan.image_to_scan
     )
@@ -124,7 +124,7 @@ def test_process_image_not_already_scanned(container_sca_scan):
         container_sca_scan.secret_tool,
         container_sca_scan.token_engine_container,
         "my_image:1234",
-        "my_image:1234_scan_result.json",
+        "my_image:1234_scan_result.csv",
         "base_image:latest",
         {'exclusions': 'exclusions'},
         False,


### PR DESCRIPTION
The format of the Prisma scan result is changed from JSON to CSV

## Description

It was detected that when sending the vulnerability report from a Prisma Cloud scan to DefectDojo in JSON format, DefectDojo takes too much time to complete the process.

### Fix
The adjustment was made, changing the format from JSON to CSV.

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
