### PR TITLE
fix(azure): Modified EnvVariables to allow BUILD_REPOSITORY_PROVIDER to be None

### DIFF
--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/azure/azure_devops.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/azure/azure_devops.py
@@ -72,7 +72,7 @@ class AzureDevops(DevopsPlatformGateway):
                 ).replace(" ", "%20")
             }
             return source_code_management_uri.get(BuildVariables.Build_Repository_Provider.value().lower())
-        except ValueError as e:
+        except ValueError:
             return None
 
 

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/azure/azure_devops.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/azure/azure_devops.py
@@ -70,7 +70,12 @@ class AzureDevops(DevopsPlatformGateway):
                 f"{SystemVariables.System_TeamProject.value()}/_git/{BuildVariables.Build_Repository_Name.value()}"
             ).replace(" ", "%20")
         }
-        return source_code_management_uri.get(BuildVariables.Build_Repository_Provider.value().lower())
+        build_repository = BuildVariables.Build_Repository_Provider.value()
+        if build_repository is None:
+            return None
+        
+        return source_code_management_uri.get(build_repository.lower())
+
 
     def get_base_compact_remote_config_url(self, remote_config_repo):
         return (

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/azure/azure_devops.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/azure/azure_devops.py
@@ -57,24 +57,23 @@ class AzureDevops(DevopsPlatformGateway):
             return AzureMessageResultPipeline.SucceededWithIssues.value
 
     def get_source_code_management_uri(self):
-        source_code_management_uri = {
-            "tfsgit": (
-                f"{SystemVariables.System_TeamFoundationCollectionUri.value()}"
-                f"{SystemVariables.System_TeamProject.value()}/_git/{BuildVariables.Build_Repository_Name.value()}"
-            ).replace(" ", "%20"),
-            "github": (
-                f"https://github.com/{BuildVariables.Build_Repository_Name.value()}"
-            ),
-            "git": (
-                f"{SystemVariables.System_TeamFoundationCollectionUri.value()}"
-                f"{SystemVariables.System_TeamProject.value()}/_git/{BuildVariables.Build_Repository_Name.value()}"
-            ).replace(" ", "%20")
-        }
-        build_repository = BuildVariables.Build_Repository_Provider.value()
-        if build_repository is None:
+        try:
+            source_code_management_uri = {
+                "tfsgit": (
+                    f"{SystemVariables.System_TeamFoundationCollectionUri.value()}"
+                    f"{SystemVariables.System_TeamProject.value()}/_git/{BuildVariables.Build_Repository_Name.value()}"
+                ).replace(" ", "%20"),
+                "github": (
+                    f"https://github.com/{BuildVariables.Build_Repository_Name.value()}"
+                ),
+                "git": (
+                    f"{SystemVariables.System_TeamFoundationCollectionUri.value()}"
+                    f"{SystemVariables.System_TeamProject.value()}/_git/{BuildVariables.Build_Repository_Name.value()}"
+                ).replace(" ", "%20")
+            }
+            return source_code_management_uri.get(BuildVariables.Build_Repository_Provider.value().lower())
+        except ValueError as e:
             return None
-        
-        return source_code_management_uri.get(build_repository.lower())
 
 
     def get_base_compact_remote_config_url(self, remote_config_repo):

--- a/tools/devsecops_engine_tools/engine_utilities/azuredevops/models/AzurePredefinedVariables.py
+++ b/tools/devsecops_engine_tools/engine_utilities/azuredevops/models/AzurePredefinedVariables.py
@@ -10,7 +10,7 @@ class EnvVariables:
     @staticmethod
     def get_value(env_name):
         env_var = os.environ.get(env_name)
-        if env_var is None and env_name:
+        if env_var is None:
             raise ValueError(f"La variable de entorno {env_name} no está definida")
         return env_var
 

--- a/tools/devsecops_engine_tools/engine_utilities/azuredevops/models/AzurePredefinedVariables.py
+++ b/tools/devsecops_engine_tools/engine_utilities/azuredevops/models/AzurePredefinedVariables.py
@@ -10,7 +10,7 @@ class EnvVariables:
     @staticmethod
     def get_value(env_name):
         env_var = os.environ.get(env_name)
-        if env_var is None and env_name != "BUILD_REPOSITORY_PROVIDER":
+        if env_var is None and env_name:
             raise ValueError(f"La variable de entorno {env_name} no está definida")
         return env_var
 

--- a/tools/devsecops_engine_tools/engine_utilities/azuredevops/models/AzurePredefinedVariables.py
+++ b/tools/devsecops_engine_tools/engine_utilities/azuredevops/models/AzurePredefinedVariables.py
@@ -10,7 +10,7 @@ class EnvVariables:
     @staticmethod
     def get_value(env_name):
         env_var = os.environ.get(env_name)
-        if env_var is None:
+        if env_var is None and env_name != "BUILD_REPOSITORY_PROVIDER":
             raise ValueError(f"La variable de entorno {env_name} no está definida")
         return env_var
 


### PR DESCRIPTION
## Description

An error was detected when running the release pipelines in Azure DevOps when the variable BUILD_REPOSITORY_PROVIDER is not defined. The variable is not defined when the pipeline does not contain an artifact, which causes the exception to be generated.

### Fix
An adjustment was made to validate that if the variable BUILD_REPOSITORY_PROVIDER is not defined, the function returns None instead of throwing the exception. This case should be allowed because not all release pipelines contain artifacts.

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
