### PR TITLE
fix: manage path in oauth api token request

### DIFF
--- a/tools/devsecops_engine_tools/engine_dast/src/infrastructure/driven_adapters/oauth/generic_oauth.py
+++ b/tools/devsecops_engine_tools/engine_dast/src/infrastructure/driven_adapters/oauth/generic_oauth.py
@@ -11,7 +11,7 @@ logger = MyLogger.__call__(**settings.SETTING_LOGGER).get_logger()
 class GenericOauth(AuthenticationGateway):
     def __init__(self, data, endpoint):
         self.data: dict = data
-        self.endpoint = endpoint
+        self.endpoint: str = endpoint
         self.config = {}
 
     def process_data(self):
@@ -52,7 +52,7 @@ class GenericOauth(AuthenticationGateway):
                 "scope": self.config["scope"]
             }
 
-            url = self.endpoint + self.config["path"]
+            url = self.endpoint + self.config["path"] if not self.config["path"].startswith("http") else self.config["path"]
             headers = self.config["headers"]
             response = requests.request(
                 self.config["method"], url, headers=headers, data=data, timeout=5


### PR DESCRIPTION
### Fix
add the endpoint to the url of the api request to get the oauth token only if it is not a different api.

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
