### PR TITLE
fix(break_build): adjust in function _handle_cve_policy for allow python version 3.8

### DIFF
--- a/tools/devsecops_engine_tools/engine_core/src/domain/usecases/break_build.py
+++ b/tools/devsecops_engine_tools/engine_core/src/domain/usecases/break_build.py
@@ -178,7 +178,7 @@ class BreakBuild:
                 "found": [{"id": item.id, "severity": item.severity} for item in vulnerabilities_list],
             }
 
-    def _handle_cve_policy(self, vulnerabilities_list: list[Finding], threshold):
+    def _handle_cve_policy(self, vulnerabilities_list: "list[Finding]", threshold):
         devops_platform_gateway = self.devops_platform_gateway
 
         ids_vulnerabilities = list(


### PR DESCRIPTION
## Description

When attempting to run the DevSecOps engine tools on version 3.8, it fails due to the use of lists that are not supported in this version.

### Fix
The type of the parameter received in the _handle_cve_policy function was adjusted to be compatible with Python version 3.8.

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
