### PR TITLE
feat(remote_config_source): A flag is added to select the platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pip3 install devsecops-engine-tools
 ### Scan running - flags (CLI)
 
 ```bash
-devsecops-engine-tools --platform_devops ["local","azure","github"] --remote_config_repo ["remote_config_repo"] --remote_config_branch ["remote_config_branch"] --module ["engine_iac", "engine_dast", "engine_secret", "engine_dependencies", "engine_container", "engine_risk", "engine_code"] --tool ["nuclei", "bearer", "checkov", "kics", "kubescape", "trufflehog", "gitleaks", "prisma", "trivy", "xray", "dependency_check"] --folder_path ["Folder path scan engine_iac, engine_code, engine_dependencies and engine_secret"] --platform ["k8s","cloudformation","docker", "openapi", "terraform"] --use_secrets_manager ["false", "true"] --use_vulnerability_management ["false", "true"] --send_metrics ["false", "true"] --token_cmdb ["token_cmdb"] --token_vulnerability_management ["token_vulnerability_management"] --token_engine_container ["token_engine_container"] --token_engine_dependencies ["token_engine_dependencies"] --token_external_checks ["token_external_checks"] --xray_mode ["scan", "audit","build-scan"] --image_to_scan ["image_to_scan"] --dast_file_path ["dast_file_path"]
+devsecops-engine-tools --platform_devops ["local","azure","github"] --remote_config_source ["local","azure","github"] --remote_config_repo ["remote_config_repo"] --remote_config_branch ["remote_config_branch"] --module ["engine_iac", "engine_dast", "engine_secret", "engine_dependencies", "engine_container", "engine_risk", "engine_code"] --tool ["nuclei", "bearer", "checkov", "kics", "kubescape", "trufflehog", "gitleaks", "prisma", "trivy", "xray", "dependency_check"] --folder_path ["Folder path scan engine_iac, engine_code, engine_dependencies and engine_secret"] --platform ["k8s","cloudformation","docker", "openapi", "terraform"] --use_secrets_manager ["false", "true"] --use_vulnerability_management ["false", "true"] --send_metrics ["false", "true"] --token_cmdb ["token_cmdb"] --token_vulnerability_management ["token_vulnerability_management"] --token_engine_container ["token_engine_container"] --token_engine_dependencies ["token_engine_dependencies"] --token_external_checks ["token_external_checks"] --xray_mode ["scan", "audit","build-scan"] --image_to_scan ["image_to_scan"] --dast_file_path ["dast_file_path"]
 ```
 
 ### Structure Remote Config
@@ -150,7 +150,7 @@ $ set +a
 
 
 ```bash
-devsecops-engine-tools --platform_devops local --remote_config_repo DevSecOps_Remote_Config --module engine_iac
+devsecops-engine-tools --platform_devops local --remote_config_source local --remote_config_repo DevSecOps_Remote_Config --module engine_iac
 
 ```
 
@@ -164,13 +164,13 @@ devsecops-engine-tools --platform_devops local --remote_config_repo DevSecOps_Re
 docker pull bancolombia/devsecops-engine-tools
 ```
 ```bash
-docker run --rm -v ./folder_to_analyze:/folder_to_analyze bancolombia/devsecops-engine-tools:latest devsecops-engine-tools --platform_devops local --remote_config_repo docker_default_remote_config --module engine_iac --folder_path /folder_to_analyze
+docker run --rm -v ./folder_to_analyze:/folder_to_analyze bancolombia/devsecops-engine-tools:latest devsecops-engine-tools --platform_devops local --remote_config_source local --remote_config_repo docker_default_remote_config --module engine_iac --folder_path /folder_to_analyze
 ```
 
 The docker image have it own default remote config with basic configuration called docker_default_remote_config, but you can define your own config and pass it as volume
 
 ```bash
-docker run --rm -v ./folder_to_analyze:/folder_to_analyze -v ./custom_remote_config:/custom_remote_config bancolombia/devsecops-engine-tools:latest devsecops-engine-tools --platform_devops local --remote_config_repo custom_remote_config --module engine_iac --folder_path /folder_to_analyze
+docker run --rm -v ./folder_to_analyze:/folder_to_analyze -v ./custom_remote_config:/custom_remote_config bancolombia/devsecops-engine-tools:latest devsecops-engine-tools --platform_devops local --remote_config_source local --remote_config_repo custom_remote_config --module engine_iac --folder_path /folder_to_analyze
 ```
 
 
@@ -200,7 +200,7 @@ stages:
           - script: |
               # Install devsecops-engine-tools
               pip3 install -q devsecops-engine-tools
-              devsecops-engine-tools --platform_devops azure --remote_config_repo remote_config --module engine_iac
+              devsecops-engine-tools --platform_devops azure --remote_config_source azure --remote_config_repo remote_config --module engine_iac
             displayName: "Engine Tools"
         env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -251,7 +251,7 @@ jobs:
         run: |
           # Install devsecops-engine-tools
           pip3 install -q devsecops-engine-tools
-          output=$(devsecops-engine-tools --platform_devops github --remote_config_repo remote_config --module engine_iac)
+          output=$(devsecops-engine-tools --platform_devops github --remote_config_source github --remote_config_repo remote_config --module engine_iac)
           echo "$output"
           if [[ $output == *"✘Failed"* ]]; then
             exit 1

--- a/docs/ENVIROMENT_CONFIGURATION.md
+++ b/docs/ENVIROMENT_CONFIGURATION.md
@@ -41,10 +41,10 @@ PYTHONPATH=tools/
             "args": [
                 "--platform_devops",
                 "local",
-                "--remote_config_repo",
-                "example_remote_config_local",
                 "--remote_config_source",
                 "github",
+                "--remote_config_repo",
+                "example_remote_config_local",
                 "--module",
                 "engine_iac",
                 "--use_secrets_manager",

--- a/docs/ENVIROMENT_CONFIGURATION.md
+++ b/docs/ENVIROMENT_CONFIGURATION.md
@@ -43,6 +43,8 @@ PYTHONPATH=tools/
                 "local",
                 "--remote_config_repo",
                 "example_remote_config_local",
+                "--remote_config_source",
+                "github",
                 "--module",
                 "engine_iac",
                 "--use_secrets_manager",

--- a/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/utils/Constants.java
+++ b/ide_extension/intellij/src/main/java/co/com/bancolombia/devsecopsenginetools/utils/Constants.java
@@ -14,7 +14,7 @@ public class Constants {
     public static final String DEFAULT_PATTERN = "#{...}#";
     public static final String AZURE_PLACEHOLDER = "$(...)";
     public static final String SERVICE_NAME = "co.com.bancolombia.devsecopsenginetools";
-    public static final String DEFAULT_IAC_SCAN_COMMAND = "docker run --rm -v {projectPath}/dev-sec-ops/iac:/iac {image} devsecops-engine-tools --platform_devops local --remote_config_repo docker_default_remote_config --module engine_iac --folder_path /iac";
+    public static final String DEFAULT_IAC_SCAN_COMMAND = "docker run --rm -v {projectPath}/dev-sec-ops/iac:/iac {image} devsecops-engine-tools --platform_devops local --remote_config_source local --remote_config_repo docker_default_remote_config --module engine_iac --folder_path /iac";
     public static final String DEFAULT_IMAGE_SCAN_COMMAND = "echo \"coming soon\"";
     public static final String DEFAULT_IMAGE = "bancolombia/devsecops-engine-tools:1.8.6";
 }

--- a/ide_extension/vscode/devsecops/src/infraestructure/drivenAdapter/IacScanner.ts
+++ b/ide_extension/vscode/devsecops/src/infraestructure/drivenAdapter/IacScanner.ts
@@ -6,7 +6,7 @@ import OutputManager from "../helper/OutputManager";
 export class IacScanner implements IScannerGateway{
 
     scan(elementToScan: string, outputChannel: OutputChannel): void {
-        exec(`/usr/local/bin/docker run --rm -v ${elementToScan}:/ms_artifact devsecops-engine-tools:10  devsecops-engine-tools --platform_devops local --remote_config_repo docker_default_remote_config --module engine_iac --tool checkov --folder_path /ms_artifact`, (error, stdout, stderr) => {
+        exec(`/usr/local/bin/docker run --rm -v ${elementToScan}:/ms_artifact devsecops-engine-tools:10  devsecops-engine-tools --platform_devops local --remote_config_source local --remote_config_repo docker_default_remote_config --module engine_iac --tool checkov --folder_path /ms_artifact`, (error, stdout, stderr) => {
             if (error) {
                 console.error(`exec error: ${error}`);
                 console.error(`stderr: ${stderr}`);

--- a/ide_extension/vscode/devsecops/src/infraestructure/drivenAdapter/ImageScanner.ts
+++ b/ide_extension/vscode/devsecops/src/infraestructure/drivenAdapter/ImageScanner.ts
@@ -7,7 +7,7 @@ import IScannerGateway from "../../domain/model/gateways/IScannerGateway";
 export class ImageScanner implements IScannerGateway{
 
     scan(elementToScan: string, outputChannel: OutputChannel): void {
-        exec(`/usr/local/bin/docker run --rm -v /var/run/docker.sock:/var/run/docker.sock devsecops-engine-tools:10 devsecops-engine-tools --platform_devops local --remote_config_repo docker_default_remote_config --module engine_container --tool trivy --image_to_scan ${elementToScan}`, (error, stdout, stderr) => {
+        exec(`/usr/local/bin/docker run --rm -v /var/run/docker.sock:/var/run/docker.sock devsecops-engine-tools:10 devsecops-engine-tools --platform_devops local --remote_config_source local --remote_config_repo docker_default_remote_config --module engine_container --tool trivy --image_to_scan ${elementToScan}`, (error, stdout, stderr) => {
             if (error) {
                 console.error(`exec error: ${error}`);
                 console.error(`stderr: ${stderr}`);

--- a/tools/devsecops_engine_tools/engine_core/src/applications/runner_engine_core.py
+++ b/tools/devsecops_engine_tools/engine_core/src/applications/runner_engine_core.py
@@ -81,6 +81,14 @@ def get_inputs_from_cli(args):
         help="Name of the branch of Remote Config Repo",
     )
     parser.add_argument(
+        "-rcs",
+        "--remote_config_source",
+        choices=["azure", "github", "local"],
+        type=str,
+        required=True,
+        help="Source of the remote config repo",
+    )
+    parser.add_argument(
         "-t",
         "--tool",
         choices=[
@@ -227,6 +235,7 @@ def get_inputs_from_cli(args):
         "platform_devops": args.platform_devops,
         "remote_config_repo": args.remote_config_repo,
         "remote_config_branch": args.remote_config_branch,
+        "remote_config_source": args.remote_config_source,
         "tool": args.tool,
         "module": args.module,
         "folder_path": args.folder_path,
@@ -259,6 +268,11 @@ def application_core():
             "github": GithubActions(),
             "local": RuntimeLocal(),
         }.get(args["platform_devops"])
+        remote_config_source_gateway = {
+            "azure": AzureDevops(),
+            "github": GithubActions(),
+            "local": RuntimeLocal(),
+        }.get(args["remote_config_source"])
         metrics_manager_gateway = S3Manager()
         printer_table_gateway = PrinterPrettyTable()
         sbom_tool_gateway = Syft()
@@ -267,6 +281,7 @@ def application_core():
             vulnerability_management_gateway,
             secrets_manager_gateway,
             devops_platform_gateway,
+            remote_config_source_gateway,
             printer_table_gateway,
             metrics_manager_gateway,
             sbom_tool_gateway,

--- a/tools/devsecops_engine_tools/engine_core/src/applications/runner_engine_core.py
+++ b/tools/devsecops_engine_tools/engine_core/src/applications/runner_engine_core.py
@@ -66,6 +66,14 @@ def get_inputs_from_cli(args):
         help="Platform where is executed",
     )
     parser.add_argument(
+        "-rcs",
+        "--remote_config_source",
+        choices=["azure", "github", "local"],
+        type=str,
+        required=True,
+        help="Source of the remote config repo",
+    )
+    parser.add_argument(
         "-rcf",
         "--remote_config_repo",
         type=str,
@@ -79,14 +87,6 @@ def get_inputs_from_cli(args):
         required=False,
         default="",
         help="Name of the branch of Remote Config Repo",
-    )
-    parser.add_argument(
-        "-rcs",
-        "--remote_config_source",
-        choices=["azure", "github", "local"],
-        type=str,
-        required=True,
-        help="Source of the remote config repo",
     )
     parser.add_argument(
         "-t",

--- a/tools/devsecops_engine_tools/engine_core/src/domain/usecases/handle_risk.py
+++ b/tools/devsecops_engine_tools/engine_core/src/domain/usecases/handle_risk.py
@@ -31,11 +31,13 @@ class HandleRisk:
         vulnerability_management: VulnerabilityManagementGateway,
         secrets_manager_gateway: SecretsManagerGateway,
         devops_platform_gateway: DevopsPlatformGateway,
+        remote_config_source_gateway: DevopsPlatformGateway,
         print_table_gateway: PrinterTableGateway,
     ):
         self.vulnerability_management = vulnerability_management
         self.secrets_manager_gateway = secrets_manager_gateway
         self.devops_platform_gateway = devops_platform_gateway
+        self.remote_config_source_gateway = remote_config_source_gateway
         self.print_table_gateway = print_table_gateway
 
     def _get_all_from_vm(self, dict_args, secret_tool, remote_config, service):
@@ -85,7 +87,7 @@ class HandleRisk:
         return filtered_engagements
 
     def _exclude_services(self, dict_args, pipeline_name, service_list):
-        risk_exclusions = self.devops_platform_gateway.get_remote_config(
+        risk_exclusions = self.remote_config_source_gateway.get_remote_config(
             dict_args["remote_config_repo"], "engine_risk/Exclusions.json", dict_args["remote_config_branch"]
         )
         if (
@@ -128,10 +130,10 @@ class HandleRisk:
         )
 
     def process(self, dict_args: any, remote_config: any):
-        risk_config = self.devops_platform_gateway.get_remote_config(
+        risk_config = self.remote_config_source_gateway.get_remote_config(
             dict_args["remote_config_repo"], "engine_risk/ConfigTool.json", dict_args["remote_config_branch"]
         )
-        risk_exclusions = self.devops_platform_gateway.get_remote_config(
+        risk_exclusions = self.remote_config_source_gateway.get_remote_config(
             dict_args["remote_config_repo"], "engine_risk/Exclusions.json", dict_args["remote_config_branch"]
         )
         pipeline_name = self.devops_platform_gateway.get_variable("pipeline_name")
@@ -227,6 +229,7 @@ class HandleRisk:
             exclusions,
             [service.name for service in new_service_list],
             self.devops_platform_gateway,
+            self.remote_config_source_gateway,
             self.print_table_gateway,
         )
 

--- a/tools/devsecops_engine_tools/engine_core/src/domain/usecases/handle_scan.py
+++ b/tools/devsecops_engine_tools/engine_core/src/domain/usecases/handle_scan.py
@@ -53,11 +53,13 @@ class HandleScan:
         vulnerability_management: VulnerabilityManagementGateway,
         secrets_manager_gateway: SecretsManagerGateway,
         devops_platform_gateway: DevopsPlatformGateway,
+        remote_config_source_gateway: DevopsPlatformGateway,
         sbom_tool_gateway: SbomManagerGateway,
     ):
         self.vulnerability_management = vulnerability_management
         self.secrets_manager_gateway = secrets_manager_gateway
         self.devops_platform_gateway = devops_platform_gateway
+        self.remote_config_source_gateway = remote_config_source_gateway
         self.sbom_tool_gateway = sbom_tool_gateway
 
     def process(self, dict_args: any, config_tool: any):
@@ -74,6 +76,7 @@ class HandleScan:
                 config_tool["ENGINE_IAC"]["TOOL"],
                 secret_tool,
                 self.devops_platform_gateway,
+                self.remote_config_source_gateway,
                 env,
             )
             self._use_vulnerability_management(
@@ -86,6 +89,7 @@ class HandleScan:
                 config_tool["ENGINE_CONTAINER"]["TOOL"],
                 secret_tool,
                 self.devops_platform_gateway,
+                self.remote_config_source_gateway
             )
             self._use_vulnerability_management(
                 config_tool,
@@ -102,6 +106,7 @@ class HandleScan:
                 config_tool["ENGINE_DAST"],
                 secret_tool,
                 self.devops_platform_gateway,
+                self.remote_config_source_gateway,
             )
             self._use_vulnerability_management(
                 config_tool, input_core, dict_args, secret_tool, env
@@ -112,6 +117,7 @@ class HandleScan:
                 dict_args,
                 config_tool["ENGINE_CODE"]["TOOL"],
                 self.devops_platform_gateway,
+                self.remote_config_source_gateway
             )
             self._use_vulnerability_management(
                 config_tool, input_core, dict_args, secret_tool, env
@@ -122,6 +128,7 @@ class HandleScan:
                 dict_args,
                 config_tool["ENGINE_SECRET"]["TOOL"],
                 self.devops_platform_gateway,
+                self.remote_config_source_gateway,
                 secret_tool,
             )
             self._use_vulnerability_management(
@@ -134,6 +141,7 @@ class HandleScan:
                 config_tool,
                 secret_tool,
                 self.devops_platform_gateway,
+                self.remote_config_source_gateway,
                 self.sbom_tool_gateway,
             )
             self._use_vulnerability_management(

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/entry_points/entry_point_core.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/entry_points/entry_point_core.py
@@ -19,12 +19,13 @@ def init_engine_core(
     vulnerability_management_gateway: any,
     secrets_manager_gateway: any,
     devops_platform_gateway: any,
+    remote_config_source_gateway: any,
     print_table_gateway: any,
     metrics_manager_gateway: any,
     sbom_tool_gateway: any,
     args: any
 ):
-    config_tool = devops_platform_gateway.get_remote_config(
+    config_tool = remote_config_source_gateway.get_remote_config(
         args["remote_config_repo"], "/engine_core/ConfigTool.json", args["remote_config_branch"]
     )
     Printers.print_logo_tool(config_tool["BANNER"])
@@ -35,6 +36,7 @@ def init_engine_core(
                 vulnerability_management_gateway,
                 secrets_manager_gateway,
                 devops_platform_gateway,
+                remote_config_source_gateway,
                 print_table_gateway,
             ).process(args, config_tool)
 
@@ -46,6 +48,7 @@ def init_engine_core(
                 vulnerability_management_gateway,
                 secrets_manager_gateway,
                 devops_platform_gateway,
+                remote_config_source_gateway,
                 sbom_tool_gateway
             ).process(args, config_tool)
 

--- a/tools/devsecops_engine_tools/engine_core/test/applications/test_runner_engine_core.py
+++ b/tools/devsecops_engine_tools/engine_core/test/applications/test_runner_engine_core.py
@@ -91,6 +91,7 @@ def test_get_inputs_from_cli(mock_parse_args):
     mock_args.platform_devops = "azure"
     mock_args.remote_config_repo = "https://github.com/example/repo"
     mock_args.remote_config_branch = ""
+    mock_args.remote_config_source = "azure"
     mock_args.module = "engine_iac"
     mock_args.tool = None
     mock_args.folder_path = "/path/to/folder"
@@ -119,6 +120,7 @@ def test_get_inputs_from_cli(mock_parse_args):
         "platform_devops": "azure",
         "remote_config_repo": "https://github.com/example/repo",
         "remote_config_branch": "",
+        "remote_config_source": "azure",
         "tool": None,
         "module": "engine_iac",
         "folder_path": "/path/to/folder",

--- a/tools/devsecops_engine_tools/engine_core/test/domain/usecases/test_handle_risk.py
+++ b/tools/devsecops_engine_tools/engine_core/test/domain/usecases/test_handle_risk.py
@@ -15,11 +15,13 @@ class TestHandleRisk(unittest.TestCase):
         self.vulnerability_management = MagicMock()
         self.secrets_manager_gateway = MagicMock()
         self.devops_platform_gateway = MagicMock()
+        self.remote_config_source_gateway = MagicMock()
         self.print_table_gateway = MagicMock()
         self.handle_risk = HandleRisk(
             self.vulnerability_management,
             self.secrets_manager_gateway,
             self.devops_platform_gateway,
+            self.remote_config_source_gateway,
             self.print_table_gateway,
         )
 
@@ -51,7 +53,7 @@ class TestHandleRisk(unittest.TestCase):
             "remote_config_branch": ""
         }
         config_tool = {"ENGINE_RISK": {"ENABLED": "true"}}
-        self.devops_platform_gateway.get_remote_config.return_value = {
+        self.remote_config_source_gateway.get_remote_config.return_value = {
             "PARENT_ANALYSIS": {"ENABLED": "true", "REGEX_GET_PARENT": "^.*?_id"},
             "HANDLE_SERVICE_NAME": {
                 "ENABLED": "true",
@@ -179,7 +181,7 @@ class TestHandleRisk(unittest.TestCase):
             MagicMock(name="service_1"),
             MagicMock(name="service_2"),
         ]
-        self.devops_platform_gateway.get_remote_config.return_value = {
+        self.remote_config_source_gateway.get_remote_config.return_value = {
             "pipeline_name": {
                 "SKIP_SERVICE": {"services": ["code_service_1", "code_service_2"]}
             }

--- a/tools/devsecops_engine_tools/engine_core/test/domain/usecases/test_handle_scan.py
+++ b/tools/devsecops_engine_tools/engine_core/test/domain/usecases/test_handle_scan.py
@@ -18,6 +18,7 @@ class TestHandleScan(unittest.TestCase):
         self.vulnerability_management = MagicMock()
         self.secrets_manager_gateway = MagicMock()
         self.devops_platform_gateway = MagicMock()
+        self.remote_config_source_gateway = MagicMock()
         self.sbom_gateway = MagicMock()
         self.threshold = Threshold(
             {
@@ -34,6 +35,7 @@ class TestHandleScan(unittest.TestCase):
             self.vulnerability_management,
             self.secrets_manager_gateway,
             self.devops_platform_gateway,
+            self.remote_config_source_gateway,
             self.sbom_gateway,
         )
 
@@ -87,6 +89,7 @@ class TestHandleScan(unittest.TestCase):
             config_tool["ENGINE_IAC"]["TOOL"],
             secret_tool,
             self.devops_platform_gateway,
+            self.remote_config_source_gateway,
             "dev",
         )
         self.vulnerability_management.send_vulnerability_management.assert_called_once()
@@ -255,7 +258,7 @@ class TestHandleScan(unittest.TestCase):
         result_findings_list, result_input_core = self.handle_scan.process(dict_args, config_tool)
         # Verifies mock have been called correctly
         mock_runner_engine_dast.assert_called_once_with(
-            dict_args, config_tool["ENGINE_DAST"], secret_tool, self.devops_platform_gateway
+            dict_args, config_tool["ENGINE_DAST"], secret_tool, self.devops_platform_gateway, self.remote_config_source_gateway
         )
         # Verifica los resultados devueltos
         self.assertEqual(result_findings_list, ["finding1", "finding2"])
@@ -298,7 +301,7 @@ class TestHandleScan(unittest.TestCase):
         self.assertEqual(result_findings_list, findings_list)
         self.assertEqual(result_input_core, input_core)
         mock_runner_secret_scan.assert_called_once_with(
-            dict_args, config_tool["ENGINE_SECRET"]["TOOL"], self.devops_platform_gateway, secret_tool
+            dict_args, config_tool["ENGINE_SECRET"]["TOOL"], self.devops_platform_gateway, self.remote_config_source_gateway, secret_tool
         )
 
     @mock.patch("devsecops_engine_tools.engine_core.src.domain.usecases.handle_scan.runner_secret_scan")
@@ -374,7 +377,7 @@ class TestHandleScan(unittest.TestCase):
         self.assertEqual(result_findings_list, findings_list)
         self.assertEqual(result_input_core, input_core)
         mock_runner_secret_scan.assert_called_once_with(
-            dict_args, config_tool["ENGINE_SECRET"]["TOOL"], self.devops_platform_gateway, secret_tool
+            dict_args, config_tool["ENGINE_SECRET"]["TOOL"], self.devops_platform_gateway, self.remote_config_source_gateway, secret_tool
         )
 
     @mock.patch(
@@ -418,5 +421,5 @@ class TestHandleScan(unittest.TestCase):
         self.assertEqual(result_input_core, input_core)
         self.secrets_manager_gateway.get_secret.assert_called_once_with(config_tool)
         mock_runner_engine_dependencies.assert_called_once_with(
-            dict_args, config_tool, secret_tool, self.devops_platform_gateway, self.sbom_gateway
+            dict_args, config_tool, secret_tool, self.devops_platform_gateway, self.remote_config_source_gateway, self.sbom_gateway
         )

--- a/tools/devsecops_engine_tools/engine_core/test/infrastructure/entry_points/test_entry_point_core.py
+++ b/tools/devsecops_engine_tools/engine_core/test/infrastructure/entry_points/test_entry_point_core.py
@@ -30,8 +30,9 @@ class TestEntryPointCore(unittest.TestCase):
         mock_scan_result = {}
 
         mock_devops_platform_gateway = mock.Mock()
+        mock_remote_config_source_gateway = mock.Mock()
 
-        mock_devops_platform_gateway.get_remote_config.return_value = mock_config_tool
+        mock_remote_config_source_gateway.get_remote_config.return_value = mock_config_tool
 
         mock_handle_scan.return_value.process.return_value = (
             mock_findings_list,
@@ -52,6 +53,7 @@ class TestEntryPointCore(unittest.TestCase):
             vulnerability_management_gateway=mock.Mock(),
             secrets_manager_gateway=mock.Mock(),
             devops_platform_gateway=mock_devops_platform_gateway,
+            remote_config_source_gateway=mock_remote_config_source_gateway,
             print_table_gateway=mock.Mock(),
             metrics_manager_gateway=mock.Mock(),
             sbom_tool_gateway=mock.Mock(),
@@ -59,7 +61,7 @@ class TestEntryPointCore(unittest.TestCase):
         )
 
         # Assert that the function calls were made with the expected arguments
-        mock_devops_platform_gateway.get_remote_config.assert_called_once_with(
+        mock_remote_config_source_gateway.get_remote_config.assert_called_once_with(
             "https://github.com/example/repo", "/engine_core/ConfigTool.json", ""
         )
         mock_handle_scan.return_value.process.assert_called_once_with(
@@ -90,14 +92,16 @@ class TestEntryPointCore(unittest.TestCase):
             "ENGINE_IAC": {"ENABLED": False, "TOOL": "tool"}
         }
         mock_devops_platform_gateway = mock.Mock()
+        mock_remote_config_source_gateway = mock.Mock()
 
-        mock_devops_platform_gateway.get_remote_config.return_value = mock_config_tool
+        mock_remote_config_source_gateway.get_remote_config.return_value = mock_config_tool
 
         # Call the function
         init_engine_core(
             vulnerability_management_gateway=mock.Mock(),
             secrets_manager_gateway=mock.Mock(),
             devops_platform_gateway=mock_devops_platform_gateway,
+            remote_config_source_gateway=mock_remote_config_source_gateway,
             print_table_gateway=mock.Mock(),
             metrics_manager_gateway=mock.Mock(),
             sbom_tool_gateway=mock.Mock(),
@@ -121,7 +125,8 @@ class TestEntryPointCore(unittest.TestCase):
             "ENGINE_RISK": {"ENABLED": "true"}
         }
         mock_devops_platform_gateway = mock.Mock()
-        mock_devops_platform_gateway.get_remote_config.return_value = mock_config_tool
+        mock_remote_config_source_gateway = mock.Mock()
+        mock_remote_config_source_gateway.get_remote_config.return_value = mock_config_tool
         mock_handle_risk.return_value.process.return_value = (
             mock.Mock(),
             mock.Mock(),
@@ -133,6 +138,7 @@ class TestEntryPointCore(unittest.TestCase):
             vulnerability_management_gateway=mock.Mock(),
             secrets_manager_gateway=mock.Mock(),
             devops_platform_gateway=mock_devops_platform_gateway,
+            remote_config_source_gateway=mock_remote_config_source_gateway,
             print_table_gateway=mock.Mock(),
             metrics_manager_gateway=mock.Mock(),
             sbom_tool_gateway=mock.Mock(),
@@ -168,8 +174,9 @@ class TestEntryPointCore(unittest.TestCase):
         mock_scan_result = {}
 
         mock_devops_platform_gateway = mock.Mock()
+        mock_remote_config_source_gateway = mock.Mock()
 
-        mock_devops_platform_gateway.get_remote_config.return_value = mock_config_tool
+        mock_remote_config_source_gateway.get_remote_config.return_value = mock_config_tool
 
         mock_handle_scan.return_value.process.return_value = (
             mock_findings_list,
@@ -191,6 +198,7 @@ class TestEntryPointCore(unittest.TestCase):
             vulnerability_management_gateway=mock.Mock(),
             secrets_manager_gateway=mock.Mock(),
             devops_platform_gateway=mock_devops_platform_gateway,
+            remote_config_source_gateway=mock_remote_config_source_gateway,
             print_table_gateway=mock.Mock(),
             metrics_manager_gateway=mock.Mock(),
             sbom_tool_gateway=mock.Mock(),

--- a/tools/devsecops_engine_tools/engine_dast/src/applications/runner_dast_scan.py
+++ b/tools/devsecops_engine_tools/engine_dast/src/applications/runner_dast_scan.py
@@ -37,7 +37,7 @@ from devsecops_engine_tools.engine_utilities import settings
 
 logger = MyLogger.__call__(**settings.SETTING_LOGGER).get_logger()
 
-def runner_engine_dast(dict_args, config_tool, secret_tool, devops_platform_gateway):
+def runner_engine_dast(dict_args, config_tool, secret_tool, devops_platform_gateway, remote_config_source_gateway):
     try:
         if config_tool["TOOL"].lower() == "nuclei": # tool_gateway is the main Tool
             tool_run = NucleiTool()
@@ -104,7 +104,7 @@ def runner_engine_dast(dict_args, config_tool, secret_tool, devops_platform_gate
         )
     except Exception as e:
         logger.error(f"Error engine_dast: {e}")
-        config_tool_dast = devops_platform_gateway.get_remote_config(
+        config_tool_dast = remote_config_source_gateway.get_remote_config(
             dict_args["remote_config_repo"], "engine_dast/ConfigTool.json", dict_args["remote_config_branch"]
         )
         if config_tool_dast["IGNORE_ERRORS"]:

--- a/tools/devsecops_engine_tools/engine_dast/src/domain/usecases/dast_scan.py
+++ b/tools/devsecops_engine_tools/engine_dast/src/domain/usecases/dast_scan.py
@@ -21,11 +21,13 @@ class DastScan:
         self,
         tool_gateway: ToolGateway,
         devops_platform_gateway: DevopsPlatformGateway,
+        remote_config_source_gateway: DevopsPlatformGateway,
         data_target,
         aditional_tools: "List[ToolGateway]"
     ):
         self.tool_gateway = tool_gateway
         self.devops_platform_gateway = devops_platform_gateway
+        self.remote_config_source_gateway = remote_config_source_gateway
         self.data_target = data_target
         self.other_tools = aditional_tools
 
@@ -56,11 +58,11 @@ class DastScan:
     def process(
         self, dict_args, secret_tool, config_tool
     ) -> "Tuple[List, InputCore]":
-        init_config_tool = self.devops_platform_gateway.get_remote_config(
+        init_config_tool = self.remote_config_source_gateway.get_remote_config(
             dict_args["remote_config_repo"], "engine_dast/ConfigTool.json"
         )
 
-        exclusions = self.devops_platform_gateway.get_remote_config(
+        exclusions = self.remote_config_source_gateway.get_remote_config(
             dict_args["remote_config_repo"],
             "engine_dast/Exclusions.json"
         )

--- a/tools/devsecops_engine_tools/engine_dast/src/infrastructure/entry_points/entry_point_dast.py
+++ b/tools/devsecops_engine_tools/engine_dast/src/infrastructure/entry_points/entry_point_dast.py
@@ -4,6 +4,7 @@ from devsecops_engine_tools.engine_dast.src.domain.usecases.dast_scan import (
 
 def init_engine_dast(
     devops_platform_gateway,
+    remote_config_source_gateway,
     tool_gateway,
     dict_args,
     secret_tool,
@@ -11,5 +12,5 @@ def init_engine_dast(
     extra_tools,
     target_data
 ):
-    dast_scan = DastScan(tool_gateway, devops_platform_gateway, target_data, extra_tools)
+    dast_scan = DastScan(tool_gateway, devops_platform_gateway, remote_config_source_gateway, target_data, extra_tools)
     return dast_scan.process(dict_args, secret_tool, config_tool)

--- a/tools/devsecops_engine_tools/engine_dast/test/applications/test_runner_dast_scan.py
+++ b/tools/devsecops_engine_tools/engine_dast/test/applications/test_runner_dast_scan.py
@@ -45,9 +45,10 @@ class TestRunnerEngineDast(unittest.TestCase):
         config_tool = {"ENABLED": "true", "TOOL": "NUCLEI", "EXTRA_TOOLS": ["JWT"]}
         secret_tool = {"github_token": "example_token"}
         devops_platform_gateway = mock.Mock()
+        remote_config_source_gateway = mock.Mock()
 
         # Llamar a la función
-        findings_list, input_core = runner_engine_dast(dict_args, config_tool, secret_tool, devops_platform_gateway)
+        findings_list, input_core = runner_engine_dast(dict_args, config_tool, secret_tool, devops_platform_gateway, remote_config_source_gateway)
 
         # Verificar que las funciones mockeadas fueron llamadas correctamente
         mock_load_json_file.assert_called_once_with(dict_args["dast_file_path"])
@@ -103,9 +104,10 @@ class TestRunnerEngineDast(unittest.TestCase):
         config_tool = {"ENABLED": "true", "TOOL": "NUCLEI", "EXTRA_TOOLS": []}
         secret_tool = {"github_token": "example_token"}
         devops_platform_gateway = mock.Mock()
+        remote_config_source_gateway = mock.Mock()
 
         # Llamar a la función
-        findings_list, input_core = runner_engine_dast(dict_args, config_tool, secret_tool, devops_platform_gateway)
+        findings_list, input_core = runner_engine_dast(dict_args, config_tool, secret_tool, devops_platform_gateway, remote_config_source_gateway)
 
         # Verificar que las funciones mockeadas fueron llamadas correctamente
         mock_load_json_file.assert_called_once_with(dict_args["dast_file_path"])

--- a/tools/devsecops_engine_tools/engine_dast/test/domain/usecases/test_dast_scan.py
+++ b/tools/devsecops_engine_tools/engine_dast/test/domain/usecases/test_dast_scan.py
@@ -12,6 +12,7 @@ class TestDastScan(unittest.TestCase):
         self.tool_gateway_mock = Mock(spec=ToolGateway)
         self.tool_gateway_mock.TOOL = "jwt"
         self.devops_platform_gateway_mock = Mock(spec=DevopsPlatformGateway)
+        self.remote_config_source_gateway = Mock(spec=DevopsPlatformGateway)
         self.data_target_mock = Mock()
         self.additional_tools_mock = [self.tool_gateway_mock]
 
@@ -19,6 +20,7 @@ class TestDastScan(unittest.TestCase):
         self.dast_scan = DastScan(
             tool_gateway=self.tool_gateway_mock,
             devops_platform_gateway=self.devops_platform_gateway_mock,
+            remote_config_source_gateway=self.remote_config_source_gateway,
             data_target=self.data_target_mock,
             aditional_tools=self.additional_tools_mock
         )
@@ -85,7 +87,7 @@ class TestDastScan(unittest.TestCase):
         finding_list = ["finding1", "finding2"]
         path_file_results = "path/to/results"
 
-        self.devops_platform_gateway_mock.get_remote_config.side_effect = [init_config_tool, exclusions]
+        self.remote_config_source_gateway.get_remote_config.side_effect = [init_config_tool, exclusions]
         self.tool_gateway_mock.run_tool.return_value = (finding_list, path_file_results)
         self.additional_tools_mock[0].run_tool.return_value = (finding_list, path_file_results)
 
@@ -93,7 +95,7 @@ class TestDastScan(unittest.TestCase):
 
         result, _ = self.dast_scan.process(dict_args, secret_tool, config_tool)
 
-        self.devops_platform_gateway_mock.get_remote_config.assert_any_call(
+        self.remote_config_source_gateway.get_remote_config.assert_any_call(
             dict_args["remote_config_repo"], "engine_dast/Exclusions.json"
         )
 

--- a/tools/devsecops_engine_tools/engine_risk/src/applications/runner_engine_risk.py
+++ b/tools/devsecops_engine_tools/engine_risk/src/applications/runner_engine_risk.py
@@ -18,6 +18,7 @@ def runner_engine_risk(
     vm_exclusions,
     services,
     devops_platform_gateway,
+    remote_config_source_gateway,
     print_table_gateway,
 ):
     add_epss_gateway = FirstCsv()
@@ -25,6 +26,7 @@ def runner_engine_risk(
     return init_engine_risk(
         add_epss_gateway,
         devops_platform_gateway,
+        remote_config_source_gateway,
         print_table_gateway,
         dict_args,
         findings,

--- a/tools/devsecops_engine_tools/engine_risk/src/domain/usecases/get_exclusions.py
+++ b/tools/devsecops_engine_tools/engine_risk/src/domain/usecases/get_exclusions.py
@@ -8,6 +8,7 @@ class GetExclusions:
     def __init__(
         self,
         devops_platform_gateway,
+        remote_config_source_gateway,
         dict_args,
         findings,
         risk_config,
@@ -16,6 +17,7 @@ class GetExclusions:
         active_findings,
     ):
         self.devops_platform_gateway = devops_platform_gateway
+        self.remote_config_source_gateway = remote_config_source_gateway
         self.dict_args = dict_args
         self.findings = findings
         self.risk_config = risk_config
@@ -24,7 +26,7 @@ class GetExclusions:
         self.active_findings = active_findings
 
     def process(self):
-        core_config = self.devops_platform_gateway.get_remote_config(
+        core_config = self.remote_config_source_gateway.get_remote_config(
             self.dict_args["remote_config_repo"],
             "engine_core/ConfigTool.json",
             self.dict_args["remote_config_branch"],
@@ -49,7 +51,7 @@ class GetExclusions:
         return self._get_exclusions(self.risk_exclusions, "RISK")
 
     def _get_exclusions_by_practice(self, core_config, practice, path):
-        exclusions_config = self.devops_platform_gateway.get_remote_config(
+        exclusions_config = self.remote_config_source_gateway.get_remote_config(
             self.dict_args["remote_config_repo"],
             path,
             self.dict_args["remote_config_branch"],

--- a/tools/devsecops_engine_tools/engine_risk/src/infrastructure/entry_points/entry_point_risk.py
+++ b/tools/devsecops_engine_tools/engine_risk/src/infrastructure/entry_points/entry_point_risk.py
@@ -24,18 +24,19 @@ logger = MyLogger.__call__(**settings.SETTING_LOGGER).get_logger()
 def init_engine_risk(
     add_epss_gateway,
     devops_platform_gateway,
+    remote_config_source_gateway,
     print_table_gateway,
     dict_args,
     findings,
     services,
     vm_exclusions,
 ):
-    remote_config = devops_platform_gateway.get_remote_config(
+    remote_config = remote_config_source_gateway.get_remote_config(
         dict_args["remote_config_repo"],
         "engine_risk/ConfigTool.json",
         dict_args["remote_config_branch"],
     )
-    risk_exclusions = devops_platform_gateway.get_remote_config(
+    risk_exclusions = remote_config_source_gateway.get_remote_config(
         dict_args["remote_config_repo"],
         "engine_risk/Exclusions.json",
         dict_args["remote_config_branch"],
@@ -61,6 +62,7 @@ def init_engine_risk(
 
     get_exclusions = GetExclusions(
         devops_platform_gateway,
+        remote_config_source_gateway,
         dict_args,
         data_added,
         remote_config,

--- a/tools/devsecops_engine_tools/engine_risk/test/applications/test_runner_engine_risk.py
+++ b/tools/devsecops_engine_tools/engine_risk/test/applications/test_runner_engine_risk.py
@@ -9,6 +9,7 @@ from devsecops_engine_tools.engine_risk.src.applications.runner_engine_risk impo
 )
 def test_runner_engine_risk(mock_init_engine_risk):
     devops_platform_gateway = "devops_platform_gateway"
+    remote_config_source_gateway = "remote_config_source_gateway"
     print_table_gateway = "print_table_gateway"
     dict_args = {"key": "value"}
     findings = []
@@ -21,6 +22,7 @@ def test_runner_engine_risk(mock_init_engine_risk):
         vm_exclusions,
         services,
         devops_platform_gateway,
+        remote_config_source_gateway,
         print_table_gateway,
     )
 

--- a/tools/devsecops_engine_tools/engine_risk/test/domain/usecases/test_get_exclusions.py
+++ b/tools/devsecops_engine_tools/engine_risk/test/domain/usecases/test_get_exclusions.py
@@ -20,6 +20,7 @@ def test_process(
 
     get_exclusions = GetExclusions(
         MagicMock(),
+        MagicMock(),
         {"remote_config_repo": "repo", "remote_config_branch": "repo"},
         MagicMock(),
         {"EXCLUSIONS_PATHS": {"tag1": "path1"}},
@@ -46,6 +47,7 @@ def test_get_risk_exclusions(mock_get_exclusions):
         MagicMock(),
         MagicMock(),
         MagicMock(),
+        MagicMock(),
         "pipeline_name",
         MagicMock(),
     )
@@ -60,6 +62,7 @@ def test_get_risk_exclusions(mock_get_exclusions):
 )
 def test_get_exclusions_by_practice(mock_get_exclusions):
     get_exclusions = GetExclusions(
+        MagicMock(),
         MagicMock(),
         MagicMock(),
         MagicMock(),
@@ -99,6 +102,7 @@ def test_get_exclusions(mock_exclusions):
         MagicMock(),
         MagicMock(),
         MagicMock(),
+        MagicMock(),
         ["service1", "service2"],
         MagicMock(),
     )
@@ -113,6 +117,7 @@ def test_get_unique_tags():
         MagicMock(tags=["tag2", "tag3"]),
     ]
     get_exclusions = GetExclusions(
+        MagicMock(),
         MagicMock(),
         MagicMock(),
         findings,
@@ -149,6 +154,7 @@ def test_get_exclusions_new_vuln(mock_datetime, mock_exclusions):
 
     get_exclusions = GetExclusions(
         devops_platform_gateway=MagicMock(),
+        remote_config_source_gateway=MagicMock(),
         dict_args={"remote_config_repo": "repo", "remote_config_branch": "branch"},
         findings=[],
         risk_config=MagicMock(),

--- a/tools/devsecops_engine_tools/engine_risk/test/infrastructure/entry_points/test_entry_point_risk.py
+++ b/tools/devsecops_engine_tools/engine_risk/test/infrastructure/entry_points/test_entry_point_risk.py
@@ -24,6 +24,7 @@ def test_init_engine_risk(
     services = ["service1", "service2"]
     vm_exclusions = ["exclusion1", "exclusion2"]
     mock_devops_platform_gateway = MagicMock()
+    mock_remote_config_source_gateway = MagicMock()
     mock_print_table_gateway = MagicMock()
 
     # Configurar la instancia de HandleFilters correctamente
@@ -39,6 +40,7 @@ def test_init_engine_risk(
     init_engine_risk(
         MagicMock(),
         mock_devops_platform_gateway,
+        mock_remote_config_source_gateway,
         mock_print_table_gateway,
         dict_args,
         findings,
@@ -46,7 +48,7 @@ def test_init_engine_risk(
         vm_exclusions,
     )
 
-    assert mock_devops_platform_gateway.get_remote_config.call_count == 2
+    assert mock_remote_config_source_gateway.get_remote_config.call_count == 2
     instance_handle_filters.filter.assert_called_once_with(findings)
     instance_handle_filters.filter_duplicated.assert_called_once()
     instance_handle_filters.filter_tags_days.assert_called_once()
@@ -64,11 +66,13 @@ def test_init_engine_risk_no_findings(mock_logger):
     services = ["service1", "service2"]
     vm_exclusions = ["exclusion1", "exclusion2"]
     mock_devops_platform_gateway = MagicMock()
+    mock_remote_config_source_gateway = MagicMock()
     mock_print_table_gateway = MagicMock()
 
     init_engine_risk(
         MagicMock(),
         mock_devops_platform_gateway,
+        mock_remote_config_source_gateway,
         mock_print_table_gateway,
         dict_args,
         findings,

--- a/tools/devsecops_engine_tools/engine_sast/engine_code/src/applications/runner_engine_code.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_code/src/applications/runner_engine_code.py
@@ -8,7 +8,7 @@ from devsecops_engine_tools.engine_utilities.git_cli.infrastructure.git_run impo
     GitRun
 )
 
-def runner_engine_code(dict_args, tool, devops_platform_gateway):
+def runner_engine_code(dict_args, tool, devops_platform_gateway, remote_config_source_gateway):
     try:
         tool_gateway = None
         git_gateway = GitRun()
@@ -17,6 +17,7 @@ def runner_engine_code(dict_args, tool, devops_platform_gateway):
 
         return init_engine_sast_code(
             devops_platform_gateway=devops_platform_gateway,
+            remote_config_source_gateway=remote_config_source_gateway,
             tool_gateway=tool_gateway,
             dict_args=dict_args,
             git_gateway=git_gateway,

--- a/tools/devsecops_engine_tools/engine_sast/engine_code/src/domain/usecases/code_scan.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_code/src/domain/usecases/code_scan.py
@@ -25,14 +25,16 @@ class CodeScan:
         self,
         tool_gateway: ToolGateway,
         devops_platform_gateway: DevopsPlatformGateway,
+        remote_config_source_gateway: DevopsPlatformGateway,
         git_gateway: GitGateway,
     ):
         self.tool_gateway = tool_gateway
         self.devops_platform_gateway = devops_platform_gateway
+        self.remote_config_source_gateway = remote_config_source_gateway
         self.git_gateway = git_gateway
 
     def set_config_tool(self, dict_args):
-        init_config_tool = self.devops_platform_gateway.get_remote_config(
+        init_config_tool = self.remote_config_source_gateway.get_remote_config(
             dict_args["remote_config_repo"], "engine_sast/engine_code/ConfigTool.json", dict_args["remote_config_branch"]
         )
         scope_pipeline = self.devops_platform_gateway.get_variable("pipeline_name")
@@ -88,7 +90,7 @@ class CodeScan:
 
     def process(self, dict_args, tool):
         config_tool = self.set_config_tool(dict_args)
-        exclusions_data = self.devops_platform_gateway.get_remote_config(
+        exclusions_data = self.remote_config_source_gateway.get_remote_config(
             dict_args["remote_config_repo"], "engine_sast/engine_code/Exclusions.json"
         )
         list_exclusions, skip_tool = self.get_exclusions(tool, exclusions_data)

--- a/tools/devsecops_engine_tools/engine_sast/engine_code/src/infrastructure/entry_points/entry_point_tool.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_code/src/infrastructure/entry_points/entry_point_tool.py
@@ -2,5 +2,5 @@ from devsecops_engine_tools.engine_sast.engine_code.src.domain.usecases.code_sca
     CodeScan,
 )
 
-def init_engine_sast_code(devops_platform_gateway, tool_gateway, dict_args, git_gateway, tool):
-    return CodeScan(tool_gateway, devops_platform_gateway, git_gateway).process(dict_args, tool)
+def init_engine_sast_code(devops_platform_gateway, remote_config_source_gateway, tool_gateway, dict_args, git_gateway, tool):
+    return CodeScan(tool_gateway, devops_platform_gateway, remote_config_source_gateway, git_gateway).process(dict_args, tool)

--- a/tools/devsecops_engine_tools/engine_sast/engine_code/test/applications/test_runner_engine_code.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_code/test/applications/test_runner_engine_code.py
@@ -20,9 +20,10 @@ class TestRunnerEngineCode(unittest.TestCase):
         dict_args = {"platform_devops": "test"}
         tool = "BEARER"
         devops_platform_gateway = Mock()
+        remote_config_source_gateway = Mock()
 
         # Act
-        runner_engine_code(dict_args, tool, devops_platform_gateway)
+        runner_engine_code(dict_args, tool, devops_platform_gateway, remote_config_source_gateway)
 
         # Assert
         _, kwargs = mock_init_engine_sast_code.call_args
@@ -37,9 +38,10 @@ class TestRunnerEngineCode(unittest.TestCase):
         dict_args = {"platform_devops": "azure"}
         tool = "TEST"
         devops_platform_gateway = Mock()
+        remote_config_source_gateway = Mock()
 
         # Act
-        runner_engine_code(dict_args, tool, devops_platform_gateway)
+        runner_engine_code(dict_args, tool, devops_platform_gateway, remote_config_source_gateway)
 
         # Assert
         _, kwargs = mock_init_engine_sast_code.call_args
@@ -54,12 +56,13 @@ class TestRunnerEngineCode(unittest.TestCase):
         dict_args = {"platform_devops": "azure"}
         tool = "BEARER"
         devops_platform_gateway = Mock()
+        remote_config_source_gateway = Mock()
 
         # Custom exception
         mock_init_engine_sast_code.side_effect = Exception("Simulated error")
 
         # Act & Assert
         with self.assertRaises(Exception) as context:
-            runner_engine_code(dict_args, tool, devops_platform_gateway)
+            runner_engine_code(dict_args, tool, devops_platform_gateway, remote_config_source_gateway)
 
         self.assertEqual(str(context.exception), "Error engine_code : Simulated error")

--- a/tools/devsecops_engine_tools/engine_sast/engine_code/test/domain/usecases/test_code_scan.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_code/test/domain/usecases/test_code_scan.py
@@ -21,12 +21,14 @@ class TestCodeScan(unittest.TestCase):
         # Mock gateways
         self.mock_tool_gateway = Mock(spec=ToolGateway)
         self.mock_devops_platform_gateway = Mock(spec=DevopsPlatformGateway)
+        self.mock_remote_config_source_gateway = Mock(spec=DevopsPlatformGateway)
         self.mock_git_gateway = Mock(spec=GitGateway)
 
         # CodeScan instance with Mocks
         self.code_scan = CodeScan(
             tool_gateway=self.mock_tool_gateway,
             devops_platform_gateway=self.mock_devops_platform_gateway,
+            remote_config_source_gateway=self.mock_remote_config_source_gateway,
             git_gateway=self.mock_git_gateway
         )
 
@@ -35,14 +37,14 @@ class TestCodeScan(unittest.TestCase):
     )
     def test_set_config_tool(self, mock_config_tool):
         # Arrange
-        self.mock_devops_platform_gateway.get_remote_config.return_value = {"test_key": "test_value"}
+        self.mock_remote_config_source_gateway.get_remote_config.return_value = {"test_key": "test_value"}
         self.mock_devops_platform_gateway.get_variable.return_value = "pipeline_test_name"
 
         # Act
         self.code_scan.set_config_tool({"remote_config_repo": "test_repo", "remote_config_branch": ""})
 
         # Assert
-        self.mock_devops_platform_gateway.get_remote_config.assert_called_once_with(
+        self.mock_remote_config_source_gateway.get_remote_config.assert_called_once_with(
             "test_repo", "engine_sast/engine_code/ConfigTool.json", ""
         )
         self.mock_devops_platform_gateway.get_variable.assert_called_once_with("pipeline_name")

--- a/tools/devsecops_engine_tools/engine_sast/engine_code/test/infrastructure/entry_points/test_entry_point_tool.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_code/test/infrastructure/entry_points/test_entry_point_tool.py
@@ -12,6 +12,7 @@ class TestInitEngineSastCode(unittest.TestCase):
     def test_init_engine_sast_code(self, mock_code_scan):
         # Arrange
         mock_devops_platform_gateway = MagicMock()
+        mock_remote_config_source_gateway = MagicMock()
         mock_tool_gateway = MagicMock()
         mock_git_gateway = MagicMock()
         
@@ -25,6 +26,7 @@ class TestInitEngineSastCode(unittest.TestCase):
         # Act
         findings_list, input_core = init_engine_sast_code(
             mock_devops_platform_gateway, 
+            mock_remote_config_source_gateway,
             mock_tool_gateway, 
             dict_args, 
             mock_git_gateway, 
@@ -35,6 +37,7 @@ class TestInitEngineSastCode(unittest.TestCase):
         mock_code_scan.assert_called_once_with(
             mock_tool_gateway,
             mock_devops_platform_gateway,
+            mock_remote_config_source_gateway,
             mock_git_gateway
         )
         mock_code_scan_instance.process.assert_called_once_with(dict_args, tool)

--- a/tools/devsecops_engine_tools/engine_sast/engine_iac/src/applications/runner_iac_scan.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_iac/src/applications/runner_iac_scan.py
@@ -12,7 +12,7 @@ from devsecops_engine_tools.engine_sast.engine_iac.src.infrastructure.driven_ada
 )
 
 
-def runner_engine_iac(dict_args, tool, secret_tool, devops_platform_gateway, env):
+def runner_engine_iac(dict_args, tool, secret_tool, devops_platform_gateway, remote_config_source_gateway, env):
     try:
         # Define driven adapters for gateways
         tool_gateway = None
@@ -28,6 +28,7 @@ def runner_engine_iac(dict_args, tool, secret_tool, devops_platform_gateway, env
 
         return init_engine_sast_rm(
             devops_platform_gateway=devops_platform_gateway,
+            remote_config_source_gateway=remote_config_source_gateway,
             tool_gateway=tool_gateway,
             dict_args=dict_args,
             secret_tool=secret_tool,

--- a/tools/devsecops_engine_tools/engine_sast/engine_iac/src/domain/usecases/iac_scan.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_iac/src/domain/usecases/iac_scan.py
@@ -20,17 +20,18 @@ logger = MyLogger.__call__(**settings.SETTING_LOGGER).get_logger()
 
 class IacScan:
     def __init__(
-        self, tool_gateway: ToolGateway, devops_platform_gateway: DevopsPlatformGateway
+        self, tool_gateway: ToolGateway, devops_platform_gateway: DevopsPlatformGateway, remote_config_source_gateway: DevopsPlatformGateway
     ):
         self.tool_gateway = tool_gateway
         self.devops_platform_gateway = devops_platform_gateway
+        self.remote_config_source_gateway = remote_config_source_gateway
 
     def process(self, dict_args, secret_tool, tool, env):
-        config_tool_iac = self.devops_platform_gateway.get_remote_config(
+        config_tool_iac = self.remote_config_source_gateway.get_remote_config(
             dict_args["remote_config_repo"], "engine_sast/engine_iac/ConfigTool.json", dict_args["remote_config_branch"]
         )
 
-        exclusions = self.devops_platform_gateway.get_remote_config(
+        exclusions = self.remote_config_source_gateway.get_remote_config(
             dict_args["remote_config_repo"], "engine_sast/engine_iac/Exclusions.json", dict_args["remote_config_branch"]
         )
 

--- a/tools/devsecops_engine_tools/engine_sast/engine_iac/src/infrastructure/entry_points/entry_point_tool.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_iac/src/infrastructure/entry_points/entry_point_tool.py
@@ -2,5 +2,5 @@ from devsecops_engine_tools.engine_sast.engine_iac.src.domain.usecases.iac_scan 
     IacScan,
 )
 
-def init_engine_sast_rm(devops_platform_gateway, tool_gateway, dict_args, secret_tool, tool, env):
-    return IacScan(tool_gateway, devops_platform_gateway).process(dict_args, secret_tool, tool, env)
+def init_engine_sast_rm(devops_platform_gateway, remote_config_source_gateway, tool_gateway, dict_args, secret_tool, tool, env):
+    return IacScan(tool_gateway, devops_platform_gateway, remote_config_source_gateway).process(dict_args, secret_tool, tool, env)

--- a/tools/devsecops_engine_tools/engine_sast/engine_iac/test/applications/test_runner_iac_scan.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_iac/test/applications/test_runner_iac_scan.py
@@ -30,9 +30,10 @@ def test_runner_engine_iac(mock_entry_point_tool):
     tool = "CHECKOV"
     secret_tool = "secret"
     devops_platform_gateway = None
+    remote_config_source_gateway = None
 
     # Call the function
-    [] , input_output = runner_engine_iac(dict_args, tool, secret_tool, devops_platform_gateway, "qa")
+    [] , input_output = runner_engine_iac(dict_args, tool, secret_tool, devops_platform_gateway, remote_config_source_gateway, "qa")
 
     # Assert the expected behavior
     assert input_output == input_core
@@ -44,13 +45,14 @@ def test_runner_engine_iac_exception(mock_entry_point_tool):
         tool = 'CHECKOV'
         secret_tool = 'my_secret'
         devops_platform_gateway = None
+        remote_config_source_gateway = None
 
         # Mock the necessary methods or properties to simulate an exception
         mock_entry_point_tool.side_effect = Exception("Simulated error")
 
         # Act and Assert
         with unittest.TestCase().assertRaises(Exception) as context:
-            runner_engine_iac(dict_args, tool, secret_tool, devops_platform_gateway, "dev")
+            runner_engine_iac(dict_args, tool, secret_tool, devops_platform_gateway, remote_config_source_gateway, "dev")
 
         # Optionally, you can check the exception message or other details
         assert str(context.exception) == "Error engine_iac : Simulated error"
@@ -78,9 +80,10 @@ def test_runner_engine_iac_kubescape(mock_entry_point_tool):
     tool = "KUBESCAPE"
     secret_tool = "secret"
     devops_platform_gateway = None
+    remote_config_source_gateway = None
 
     # Call the function
-    [] , input_output = runner_engine_iac(dict_args, tool, secret_tool, devops_platform_gateway, "qa")
+    [] , input_output = runner_engine_iac(dict_args, tool, secret_tool, devops_platform_gateway, remote_config_source_gateway, "qa")
 
     # Assert the expected behavior
     assert input_output == input_core
@@ -108,9 +111,10 @@ def test_runner_engine_iac_kics(mock_entry_point_tool):
     tool = "KICS"
     secret_tool = "secret"
     devops_platform_gateway = None
+    remote_config_source_gateway = None
 
     # Call the function
-    [] , input_output = runner_engine_iac(dict_args, tool, secret_tool, devops_platform_gateway, "qa")
+    [] , input_output = runner_engine_iac(dict_args, tool, secret_tool, devops_platform_gateway, remote_config_source_gateway, "qa")
 
     # Assert the expected behavior
     assert input_output == input_core

--- a/tools/devsecops_engine_tools/engine_sast/engine_iac/test/domain/usecases/test_iac_scan.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_iac/test/domain/usecases/test_iac_scan.py
@@ -9,7 +9,8 @@ class TestIacScan(unittest.TestCase):
     def setUp(self):
         self.tool_gateway = MagicMock()
         self.devops_platform_gateway = MagicMock()
-        self.iac_scan = IacScan(self.tool_gateway, self.devops_platform_gateway)
+        self.remote_config_source_gateway = MagicMock()
+        self.iac_scan = IacScan(self.tool_gateway, self.devops_platform_gateway, self.remote_config_source_gateway)
 
     def side_effect(self, arg):
         if arg == "stage":
@@ -30,7 +31,7 @@ class TestIacScan(unittest.TestCase):
         tool = "CHECKOV"
 
         # Mock the return values of the dependencies
-        self.devops_platform_gateway.get_remote_config.return_value = {
+        self.remote_config_source_gateway.get_remote_config.return_value = {
             "SEARCH_PATTERN": ["AW", "NU"],
             "IGNORE_SEARCH_PATTERN": "(.*_test)",
             "EXCLUSIONS_PATH": "Exclusions.json",
@@ -87,7 +88,7 @@ class TestIacScan(unittest.TestCase):
         secret_tool = "example_secret"
         tool = "CHECKOV"
 
-        self.devops_platform_gateway.get_remote_config.side_effect = [
+        self.remote_config_source_gateway.get_remote_config.side_effect = [
             # Resultado para el primer llamado (init_config_tool)
             {
                 "SEARCH_PATTERN": ["AW", "NU"],

--- a/tools/devsecops_engine_tools/engine_sast/engine_iac/test/infrastructure/entry_points/test_entry_point_tool.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_iac/test/infrastructure/entry_points/test_entry_point_tool.py
@@ -23,13 +23,14 @@ def test_init_engine_sast_rm(mock_iac_scan):
 
     # Define the input arguments
     devops_platform_gateway = MagicMock()
+    remote_config_source_gateway = MagicMock()
     tool_gateway = MagicMock()
     dict_args = {}
     secret_tool = "secret"
     tool = "CHECKOV"
 
     # Call the function
-    [] , input_output = init_engine_sast_rm(devops_platform_gateway, tool_gateway, dict_args, secret_tool, tool, "dev")
+    [] , input_output = init_engine_sast_rm(devops_platform_gateway, remote_config_source_gateway, tool_gateway, dict_args, secret_tool, tool, "dev")
 
     # Assert the expected behavior
     assert input_output == input_core

--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/src/applications/runner_secret_scan.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/src/applications/runner_secret_scan.py
@@ -17,7 +17,7 @@ from devsecops_engine_tools.engine_utilities.git_cli.infrastructure.git_run impo
     GitRun
     )
 
-def runner_secret_scan(dict_args, tool, devops_platform_gateway, secret_tool):
+def runner_secret_scan(dict_args, tool, devops_platform_gateway, remote_config_source_gateway, secret_tool):
     try:
         tool_deserealizator = None
         tool_gateway = None
@@ -31,6 +31,7 @@ def runner_secret_scan(dict_args, tool, devops_platform_gateway, secret_tool):
 
         return engine_secret_scan(
             devops_platform_gateway = devops_platform_gateway,
+            remote_config_source_gateway=remote_config_source_gateway,
             tool_gateway = tool_gateway,
             dict_args = dict_args,
             tool=tool,

--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/src/domain/usecases/secret_scan.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/src/domain/usecases/secret_scan.py
@@ -18,11 +18,13 @@ class SecretScan:
         self,
         tool_gateway: ToolGateway,
         devops_platform_gateway: DevopsPlatformGateway,
+        remote_config_source_gateway: DevopsPlatformGateway,
         tool_deserialize: DeseralizatorGateway,
         git_gateway: GitGateway
         ):
         self.tool_gateway = tool_gateway
         self.devops_platform_gateway = devops_platform_gateway
+        self.remote_config_source_gateway = remote_config_source_gateway
         self.tool_deserialize = tool_deserialize
         self.git_gateway = git_gateway
 
@@ -69,7 +71,7 @@ class SecretScan:
     
     def complete_config_tool(self, dict_args, tool):
         tool = str(tool).lower()
-        init_config_tool = self.devops_platform_gateway.get_remote_config(
+        init_config_tool = self.remote_config_source_gateway.get_remote_config(
             dict_args["remote_config_repo"], "engine_sast/engine_secret/ConfigTool.json", dict_args["remote_config_branch"]
         )
         init_config_tool['SCOPE_PIPELINE'] = self.devops_platform_gateway.get_variable("pipeline_name")

--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/src/domain/usecases/set_input_core.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/src/domain/usecases/set_input_core.py
@@ -10,11 +10,13 @@ class SetInputCore:
     def __init__(
         self,
         tool_remote: DevopsPlatformGateway,
+        remote_config_source_gateway: DevopsPlatformGateway,
         dict_args,
         tool,
         config_tool,
     ):
         self.tool_remote = tool_remote
+        self.remote_config_source_gateway = remote_config_source_gateway
         self.dict_args = dict_args
         self.tool = tool
         self.config_tool = config_tool
@@ -26,7 +28,7 @@ class SetInputCore:
         Returns:
             dict: Remote configuration.
         """
-        return self.tool_remote.get_remote_config(
+        return self.remote_config_source_gateway.get_remote_config(
             self.dict_args["remote_config_repo"], file_path, self.dict_args["remote_config_branch"]
         )
 

--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/src/infrastructure/entry_points/entry_point_tool.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/src/infrastructure/entry_points/entry_point_tool.py
@@ -4,13 +4,13 @@ from devsecops_engine_tools.engine_sast.engine_secret.src.domain.usecases.set_in
     SetInputCore,
 )
 
-def engine_secret_scan(devops_platform_gateway, tool_gateway, dict_args, tool, tool_deserealizator, git_gateway, secret_tool):
-    exclusions = devops_platform_gateway.get_remote_config(
+def engine_secret_scan(devops_platform_gateway, remote_config_source_gateway, tool_gateway, dict_args, tool, tool_deserealizator, git_gateway, secret_tool):
+    exclusions = remote_config_source_gateway.get_remote_config(
         dict_args["remote_config_repo"], "engine_sast/engine_secret/Exclusions.json", dict_args["remote_config_branch"]
     )
-    secret_scan = SecretScan(tool_gateway, devops_platform_gateway, tool_deserealizator, git_gateway)
+    secret_scan = SecretScan(tool_gateway, devops_platform_gateway, remote_config_source_gateway, tool_deserealizator, git_gateway)
     config_tool, skip_tool_isp = secret_scan.complete_config_tool(dict_args, tool)
     skip_tool = secret_scan.skip_from_exclusion(exclusions, skip_tool_isp)
     finding_list, file_path_findings = secret_scan.process(skip_tool, config_tool, secret_tool, dict_args, tool)
-    input_core = SetInputCore(devops_platform_gateway, dict_args, tool, config_tool)
+    input_core = SetInputCore(devops_platform_gateway, remote_config_source_gateway, dict_args, tool, config_tool)
     return finding_list, input_core.set_input_core(file_path_findings)

--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/test/applications/test_runner_secret_scan.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/test/applications/test_runner_secret_scan.py
@@ -29,9 +29,10 @@ def test_runner_secret_scan(mock_entry_point_tool):
     tool = "TRUFFLEHOG"
     secret_tool = "secret"
     devops_platform_gateway = None
+    remote_config_source_gateway = None
 
     # Call the function
-    [] , input_output = runner_secret_scan(dict_args, tool, devops_platform_gateway, secret_tool)
+    [] , input_output = runner_secret_scan(dict_args, tool, devops_platform_gateway, remote_config_source_gateway, secret_tool)
 
     # Assert the expected behavior
     assert input_output == input_core
@@ -43,13 +44,14 @@ def test_runner_secret_scan_exception(mock_entry_point_tool):
         tool = 'GITLEAKS'
         secret_tool = "secret"
         devops_platform_gateway = None
+        remote_config_source_gateway = None
         
         # Mock the necessary methods or properties to simulate an exception
         mock_entry_point_tool.side_effect = Exception("Simulated error")
 
         # Act and Assert
         with unittest.TestCase().assertRaises(Exception) as context:
-            runner_secret_scan(dict_args, tool, devops_platform_gateway, secret_tool)
+            runner_secret_scan(dict_args, tool, devops_platform_gateway, remote_config_source_gateway, secret_tool)
 
         # Optionally, you can check the exception message or other details
         assert str(context.exception) == "Error engine_secret : Simulated error"

--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/test/domain/usecases/test_secret_scan.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/test/domain/usecases/test_secret_scan.py
@@ -44,17 +44,21 @@ class TestSecretScan(unittest.TestCase):
         "devsecops_engine_tools.engine_core.src.domain.model.gateway.devops_platform_gateway.DevopsPlatformGateway"
     )
     @patch(
+        "devsecops_engine_tools.engine_core.src.domain.model.gateway.devops_platform_gateway.DevopsPlatformGateway"
+    )
+    @patch(
         "devsecops_engine_tools.engine_sast.engine_secret.src.domain.model.gateway.gateway_deserealizator.DeseralizatorGateway"
     )
     @patch(
         "devsecops_engine_tools.engine_sast.engine_secret.src.domain.model.gateway.tool_gateway.ToolGateway"
     )
     def test_process(
-        self, mock_tool_gateway, mock_devops_gateway, mock_deserialize_gateway, mock_git_gateway
+        self, mock_tool_gateway, mock_devops_gateway, mock_remote_config_source, mock_deserialize_gateway, mock_git_gateway
     ):
         # Configuración de mocks
         mock_tool_gateway_instance = mock_tool_gateway.return_value
         mock_devops_gateway_instance = mock_devops_gateway.return_value
+        mock_remote_config_source_instance = mock_remote_config_source.return_value
         mock_deserialize_gateway_instance = mock_deserialize_gateway.return_value
         mock_git_gateway_instance = mock_git_gateway.return_value
         mock_dict_args = {
@@ -71,6 +75,7 @@ class TestSecretScan(unittest.TestCase):
         secret_scan = SecretScan(
             mock_tool_gateway_instance,
             mock_devops_gateway_instance,
+            mock_remote_config_source_instance,
             mock_deserialize_gateway_instance,
             mock_git_gateway_instance
         )
@@ -79,7 +84,7 @@ class TestSecretScan(unittest.TestCase):
             "vulnerability_data"
         ]
 
-        mock_devops_gateway_instance.get_remote_config.return_value = json_config
+        mock_remote_config_source_instance.get_remote_config.return_value = json_config
         mock_devops_gateway_instance.get_variable.return_value = "example_pipeline"
         mock_tool_gateway_instance.run_tool_secret_scan.return_value = (
             "vulnerability_data", "path/findings"
@@ -99,17 +104,21 @@ class TestSecretScan(unittest.TestCase):
         "devsecops_engine_tools.engine_core.src.domain.model.gateway.devops_platform_gateway.DevopsPlatformGateway"
     )
     @patch(
+        "devsecops_engine_tools.engine_core.src.domain.model.gateway.devops_platform_gateway.DevopsPlatformGateway"
+    )
+    @patch(
         "devsecops_engine_tools.engine_sast.engine_secret.src.domain.model.gateway.gateway_deserealizator.DeseralizatorGateway"
     )
     @patch(
         "devsecops_engine_tools.engine_sast.engine_secret.src.domain.model.gateway.tool_gateway.ToolGateway"
     )
     def test_process_empty(
-        self, mock_tool_gateway, mock_devops_gateway, mock_deserialize_gateway, mock_git_gateway
+        self, mock_tool_gateway, mock_devops_gateway, mock_remote_config_source, mock_deserialize_gateway, mock_git_gateway
     ):
         # Configuración de mocks
         mock_tool_gateway_instance = mock_tool_gateway.return_value
         mock_devops_gateway_instance = mock_devops_gateway.return_value
+        mock_remote_config_source_instance = mock_remote_config_source.return_value
         mock_deserialize_gateway_instance = mock_deserialize_gateway.return_value
         mock_git_gateway_instance = mock_git_gateway.return_value
         mock_dict_args = {
@@ -126,13 +135,14 @@ class TestSecretScan(unittest.TestCase):
         secret_scan = SecretScan(
             mock_tool_gateway_instance,
             mock_devops_gateway_instance,
+            mock_remote_config_source_instance,
             mock_deserialize_gateway_instance,
             mock_git_gateway_instance
         )
 
         mock_deserialize_gateway_instance.get_list_vulnerability.return_value = []
 
-        mock_devops_gateway_instance.get_remote_config.return_value = json_config
+        mock_remote_config_source_instance.get_remote_config.return_value = json_config
         mock_devops_gateway_instance.get_variable.return_value = "example_pipeline"
         mock_tool_gateway_instance.run_tool_secret_scan.return_value = "", ""
 
@@ -150,20 +160,25 @@ class TestSecretScan(unittest.TestCase):
         "devsecops_engine_tools.engine_core.src.domain.model.gateway.devops_platform_gateway.DevopsPlatformGateway"
     )
     @patch(
+        "devsecops_engine_tools.engine_core.src.domain.model.gateway.devops_platform_gateway.DevopsPlatformGateway"
+    )
+    @patch(
         "devsecops_engine_tools.engine_sast.engine_secret.src.domain.model.gateway.gateway_deserealizator.DeseralizatorGateway"
     )
     @patch(
         "devsecops_engine_tools.engine_sast.engine_secret.src.domain.model.gateway.tool_gateway.ToolGateway"
     )
-    def test_skip_tool_true(self, mock_tool_gateway, mock_devops_gateway, mock_deserialize_gateway, mock_git_gateway):
+    def test_skip_tool_true(self, mock_tool_gateway, mock_devops_gateway, mock_remote_config_source, mock_deserialize_gateway, mock_git_gateway):
         mock_tool_gateway_instance = mock_tool_gateway.return_value
         mock_devops_gateway_instance = mock_devops_gateway.return_value
+        mock_remote_config_source_instance = mock_remote_config_source.return_value
         mock_deserialize_gateway_instance = mock_deserialize_gateway.return_value
         mock_git_gateway_instance = mock_git_gateway.return_value
     
         secret_scan = SecretScan(
             mock_tool_gateway_instance,
             mock_devops_gateway_instance,
+            mock_remote_config_source_instance,
             mock_deserialize_gateway_instance,
             mock_git_gateway_instance
         )
@@ -181,20 +196,25 @@ class TestSecretScan(unittest.TestCase):
         "devsecops_engine_tools.engine_core.src.domain.model.gateway.devops_platform_gateway.DevopsPlatformGateway"
     )
     @patch(
+        "devsecops_engine_tools.engine_core.src.domain.model.gateway.devops_platform_gateway.DevopsPlatformGateway"
+    )
+    @patch(
         "devsecops_engine_tools.engine_sast.engine_secret.src.domain.model.gateway.gateway_deserealizator.DeseralizatorGateway"
     )
     @patch(
         "devsecops_engine_tools.engine_sast.engine_secret.src.domain.model.gateway.tool_gateway.ToolGateway"
     )
-    def test_skip_tool_true_isp(self, mock_tool_gateway, mock_devops_gateway, mock_deserialize_gateway, mock_git_gateway):
+    def test_skip_tool_true_isp(self, mock_tool_gateway, mock_devops_gateway, mock_remote_config_source, mock_deserialize_gateway, mock_git_gateway):
         mock_tool_gateway_instance = mock_tool_gateway.return_value
         mock_devops_gateway_instance = mock_devops_gateway.return_value
+        mock_remote_config_source_instance = mock_remote_config_source.return_value
         mock_deserialize_gateway_instance = mock_deserialize_gateway.return_value
         mock_git_gateway_instance = mock_git_gateway.return_value
     
         secret_scan = SecretScan(
             mock_tool_gateway_instance,
             mock_devops_gateway_instance,
+            mock_remote_config_source_instance,
             mock_deserialize_gateway_instance,
             mock_git_gateway_instance
         )
@@ -212,20 +232,25 @@ class TestSecretScan(unittest.TestCase):
         "devsecops_engine_tools.engine_core.src.domain.model.gateway.devops_platform_gateway.DevopsPlatformGateway"
     )
     @patch(
+        "devsecops_engine_tools.engine_core.src.domain.model.gateway.devops_platform_gateway.DevopsPlatformGateway"
+    )
+    @patch(
         "devsecops_engine_tools.engine_sast.engine_secret.src.domain.model.gateway.gateway_deserealizator.DeseralizatorGateway"
     )
     @patch(
         "devsecops_engine_tools.engine_sast.engine_secret.src.domain.model.gateway.tool_gateway.ToolGateway"
     )
-    def test_skip_tool_false(self, mock_tool_gateway, mock_devops_gateway, mock_deserialize_gateway, mock_git_gateway):
+    def test_skip_tool_false(self, mock_tool_gateway, mock_devops_gateway, mock_remote_config_source, mock_deserialize_gateway, mock_git_gateway):
         mock_tool_gateway_instance = mock_tool_gateway.return_value
         mock_devops_gateway_instance = mock_devops_gateway.return_value
+        mock_remote_config_source_instance = mock_remote_config_source.return_value
         mock_deserialize_gateway_instance = mock_deserialize_gateway.return_value
         mock_git_gateway_instance = mock_git_gateway.return_value
     
         secret_scan = SecretScan(
             mock_tool_gateway_instance,
             mock_devops_gateway_instance,
+            mock_remote_config_source_instance,
             mock_deserialize_gateway_instance,
             mock_git_gateway_instance
         )
@@ -243,28 +268,33 @@ class TestSecretScan(unittest.TestCase):
         "devsecops_engine_tools.engine_core.src.domain.model.gateway.devops_platform_gateway.DevopsPlatformGateway"
     )
     @patch(
+        "devsecops_engine_tools.engine_core.src.domain.model.gateway.devops_platform_gateway.DevopsPlatformGateway"
+    )
+    @patch(
         "devsecops_engine_tools.engine_sast.engine_secret.src.domain.model.gateway.gateway_deserealizator.DeseralizatorGateway"
     )
     @patch(
         "devsecops_engine_tools.engine_sast.engine_secret.src.domain.model.gateway.tool_gateway.ToolGateway"
     )
     def test_complete_config_tool(
-        self, mock_tool_gateway, mock_devops_gateway, mock_deserialize_gateway, mock_git_gateway
+        self, mock_tool_gateway, mock_devops_gateway, mock_remote_config_source, mock_deserialize_gateway, mock_git_gateway
     ):
         # Configuración de mocks
         mock_tool_gateway_instance = mock_tool_gateway.return_value
         mock_devops_gateway_instance = mock_devops_gateway.return_value
+        mock_remote_config_source_instance = mock_remote_config_source.return_value
         mock_deserialize_gateway_instance = mock_deserialize_gateway.return_value
         mock_git_gateway_instance = mock_git_gateway.return_value
 
         secret_scan = SecretScan(
             mock_tool_gateway_instance,
             mock_devops_gateway_instance,
+            mock_remote_config_source_instance,
             mock_deserialize_gateway_instance,
             mock_git_gateway_instance
         )
 
-        mock_devops_gateway_instance.get_remote_config.return_value = json_config
+        mock_remote_config_source_instance.get_remote_config.return_value = json_config
         mock_devops_gateway_instance.get_variable.return_value = "example_pipeline"
 
         config_tool_instance, skip_tool_isp = secret_scan.complete_config_tool(

--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/test/domain/usecases/test_set_input_core.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/test/domain/usecases/test_set_input_core.py
@@ -11,8 +11,12 @@ from devsecops_engine_tools.engine_sast.engine_secret.src.domain.usecases.set_in
 def mock_tool_remote():
     return Mock(spec=DevopsPlatformGateway)
 
+@pytest.fixture
+def mock_source_remote():
+    return Mock(spec=DevopsPlatformGateway)
 
-def test_get_exclusions(mock_tool_remote):
+
+def test_get_exclusions(mock_tool_remote, mock_source_remote):
     exclusions_data = {
       "All": {
           "TRUFFLEHOG": [
@@ -37,7 +41,7 @@ def test_get_exclusions(mock_tool_remote):
     config_tool = MagicMock()
 
     # Inicializa una instancia de SetInputCore
-    set_input_core = SetInputCore(mock_tool_remote, None, tool, config_tool)
+    set_input_core = SetInputCore(mock_tool_remote, mock_source_remote, None, tool, config_tool)
 
     # Llama al método get_exclusions
     exclusions = set_input_core.get_exclusions(exclusions_data, pipeline_name, tool)

--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/test/infrastructure/entry_points/test_entry_point_tool.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/test/infrastructure/entry_points/test_entry_point_tool.py
@@ -8,6 +8,7 @@ class TestEngineSecretScan(unittest.TestCase):
     @patch('devsecops_engine_tools.engine_sast.engine_secret.src.domain.usecases.set_input_core.SetInputCore')
     def test_engine_secret_scan(self, MockSetInputCore, MockSecretScan):
         mock_devops_platform_gateway = Mock()
+        mock_source_remote_config_gateway = Mock()
         mock_tool_gateway = Mock()
         mock_dict_args = {
             "remote_config_repo": "example_repo",
@@ -61,7 +62,7 @@ class TestEngineSecretScan(unittest.TestCase):
                     }
                 }
             }
-        mock_devops_platform_gateway.get_remote_config.side_effect = [json_exclusion ,json_config, json_exclusion]
+        mock_source_remote_config_gateway.get_remote_config.side_effect = [json_exclusion ,json_config, json_exclusion]
         secret_tool = "secret"
         skip_tool_isp = False
         
@@ -75,6 +76,7 @@ class TestEngineSecretScan(unittest.TestCase):
 
         findings, input_core_result = engine_secret_scan(
             mock_devops_platform_gateway,
+            mock_source_remote_config_gateway,
             mock_tool_gateway,
             mock_dict_args,
             mock_tool,

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/src/applications/runner_container_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/src/applications/runner_container_scan.py
@@ -18,7 +18,7 @@ from devsecops_engine_tools.engine_sca.engine_container.src.infrastructure.drive
 )
 
 
-def runner_engine_container(dict_args, tool, secret_tool, tool_remote):
+def runner_engine_container(dict_args, tool, secret_tool, tool_remote, remote_config_source_gateway):
     try:
         if tool.lower() == "trivy":
             tool_run = TrivyScan()
@@ -30,6 +30,7 @@ def runner_engine_container(dict_args, tool, secret_tool, tool_remote):
         return init_engine_sca_rm(
             tool_run,
             tool_remote,
+            remote_config_source_gateway,
             tool_images,
             tool_deseralizator,
             dict_args,

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/src/infrastructure/entry_points/entry_point_tool.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/src/infrastructure/entry_points/entry_point_tool.py
@@ -16,16 +16,17 @@ logger = MyLogger.__call__(**settings.SETTING_LOGGER).get_logger()
 def init_engine_sca_rm(
     tool_run,
     tool_remote,
+    remote_config_source_gateway,
     tool_images,
     tool_deseralizator,
     dict_args,
     secret_tool,
     tool,
 ):
-    remote_config = tool_remote.get_remote_config(
+    remote_config = remote_config_source_gateway.get_remote_config(
         dict_args["remote_config_repo"], "engine_sca/engine_container/ConfigTool.json", dict_args["remote_config_branch"]
     )
-    exclusions = tool_remote.get_remote_config(
+    exclusions = remote_config_source_gateway.get_remote_config(
         dict_args["remote_config_repo"], "engine_sca/engine_container/Exclusions.json", dict_args["remote_config_branch"]
     )
     pipeline_name = tool_remote.get_variable("pipeline_name")

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/test/applications/test_runner_container_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/test/applications/test_runner_container_scan.py
@@ -13,6 +13,6 @@ def test_init_engine_container():
         token = "token"
         tool = "PRISMA"
 
-        result = runner_engine_container(dict_args, tool, token, None)
+        result = runner_engine_container(dict_args, tool, token, None, None)
 
         mock_init_engine_sca_rm.assert_any_call

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/test/infrastructure/entry_points/test_entry_point_tool.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/test/infrastructure/entry_points/test_entry_point_tool.py
@@ -29,6 +29,7 @@ def test_init_engine_sca_rm():
             Mock(),
             Mock(),
             Mock(),
+            Mock(),
             dict_args,
             token,
             tool,
@@ -55,6 +56,7 @@ def test_init_engine_sca_rm_skip_tool():
         )
 
         deserialized, core_input, sbom_components = init_engine_sca_rm(
+            Mock(),
             Mock(),
             Mock(),
             Mock(),
@@ -92,6 +94,7 @@ def test_init_engine_sca_rm_no_exclusions():
             Mock(),
             Mock(),
             Mock(),
+            Mock(),
             dict_args,
             token,
             tool,
@@ -121,6 +124,7 @@ def test_init_engine_sca_rm_empty_remote_config():
         mock_container_sca_scan.process.return_value = "scan_result.json"
 
         deserialized, core_input, sbom_components = init_engine_sca_rm(
+            Mock(),
             Mock(),
             Mock(),
             Mock(),

--- a/tools/devsecops_engine_tools/engine_sca/engine_dependencies/src/applications/runner_dependencies_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_dependencies/src/applications/runner_dependencies_scan.py
@@ -16,7 +16,7 @@ from devsecops_engine_tools.engine_sca.engine_dependencies.src.infrastructure.en
 
 
 def runner_engine_dependencies(
-    dict_args, config_tool, secret_tool, devops_platform_gateway, sbom_tool_gateway
+    dict_args, config_tool, secret_tool, devops_platform_gateway, remote_config_source_gateway, sbom_tool_gateway
 ):
     try:
         tools_mapping = {
@@ -40,6 +40,7 @@ def runner_engine_dependencies(
         return init_engine_dependencies(
             tool_run,
             devops_platform_gateway,
+            remote_config_source_gateway,
             tool_deserializator,
             dict_args,
             secret_tool,

--- a/tools/devsecops_engine_tools/engine_sca/engine_dependencies/src/infrastructure/driven_adapters/dependency_check/README.md
+++ b/tools/devsecops_engine_tools/engine_sca/engine_dependencies/src/infrastructure/driven_adapters/dependency_check/README.md
@@ -6,7 +6,7 @@ in [Request NVD API Key](https://nvd.nist.gov/developers/request-an-api-key). Ke
 The API Key can be passed to the devsecops engine tools using the flag `--token_engine_dependencies`. For example:
 
 ```bash
-devsecops-engine-tools --platform_devops local --remote_config_repo DevSecOps_Remote_Config --module engine_dependencies --tool dependency_check --token_engine_dependencies nvd_api_key
+devsecops-engine-tools --platform_devops local --remote_config_source local --remote_config_repo DevSecOps_Remote_Config --module engine_dependencies --tool dependency_check --token_engine_dependencies nvd_api_key
 ```
 
 #### The NVD API Key, CI, and Rate Limiting

--- a/tools/devsecops_engine_tools/engine_sca/engine_dependencies/src/infrastructure/entry_points/entry_point_tool.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_dependencies/src/infrastructure/entry_points/entry_point_tool.py
@@ -25,18 +25,19 @@ logger = MyLogger.__call__(**settings.SETTING_LOGGER).get_logger()
 def init_engine_dependencies(
     tool_run,
     tool_remote: DevopsPlatformGateway,
+    remote_config_source_gateway: DevopsPlatformGateway,
     tool_deserializator,
     dict_args,
     secret_tool,
     config_tool,
     tool_sbom: SbomManagerGateway,
 ):
-    remote_config = tool_remote.get_remote_config(
+    remote_config = remote_config_source_gateway.get_remote_config(
         dict_args["remote_config_repo"],
         "engine_sca/engine_dependencies/ConfigTool.json",
         dict_args["remote_config_branch"]
     )
-    exclusions = tool_remote.get_remote_config(
+    exclusions = remote_config_source_gateway.get_remote_config(
         dict_args["remote_config_repo"],
         "engine_sca/engine_dependencies/Exclusions.json",
         dict_args["remote_config_branch"]

--- a/tools/devsecops_engine_tools/engine_sca/engine_dependencies/test/applications/test_runner_dependencies_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_dependencies/test/applications/test_runner_dependencies_scan.py
@@ -15,7 +15,7 @@ def test_init_engine_dependencies_xray():
             "ENGINE_DEPENDENCIES": {"ENABLED": "true", "TOOL": "XRAY"},
         }
 
-        result = runner_engine_dependencies(dict_args, config_tool, token, None, None)
+        result = runner_engine_dependencies(dict_args, config_tool, token, None, None, None)
 
         mock_init_engine_dependencies.assert_any_call
 
@@ -30,6 +30,6 @@ def test_init_engine_dependencies_dependency_check():
             "ENGINE_DEPENDENCIES": {"ENABLED": "true", "TOOL": "DEPENDENCY_CHECK"},
         }
 
-        result = runner_engine_dependencies(dict_args, config_tool, token, None, None)
+        result = runner_engine_dependencies(dict_args, config_tool, token, None, None, None)
 
         mock_init_engine_dependencies.assert_any_call

--- a/tools/devsecops_engine_tools/engine_sca/engine_dependencies/test/infrastructure/entry_points/test_entry_point_tool.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_dependencies/test/infrastructure/entry_points/test_entry_point_tool.py
@@ -30,6 +30,7 @@ def test_init_engine_dependencies():
             Mock(),
             Mock(),
             Mock(),
+            Mock(),
             dict_args,
             token,
             tool,
@@ -53,6 +54,7 @@ def test_init_engine_dependencies_success(mock_exists, mock_dependencies_scan, m
     # Crear mocks para las dependencias
     tool_run = MagicMock()
     tool_remote = MagicMock(spec=DevopsPlatformGateway)
+    remote_config_source_gateway = MagicMock(spec=DevopsPlatformGateway)
     tool_remote.get_variable.return_value = "main"
     tool_deserializator = MagicMock()
     tool_sbom = MagicMock(spec=SbomManagerGateway)
@@ -65,12 +67,12 @@ def test_init_engine_dependencies_success(mock_exists, mock_dependencies_scan, m
 
     # Llamar a la función
     deserialized, core_input, sbom_components = init_engine_dependencies(
-        tool_run, tool_remote, tool_deserializator, dict_args, secret_tool, config_tool, tool_sbom
+        tool_run, tool_remote, remote_config_source_gateway, tool_deserializator, dict_args, secret_tool, config_tool, tool_sbom
     )
 
     # Verificar que se llamaron las funciones esperadas
-    tool_remote.get_remote_config.assert_any_call("repo", "engine_sca/engine_dependencies/ConfigTool.json", "")
-    tool_remote.get_remote_config.assert_any_call("repo", "engine_sca/engine_dependencies/Exclusions.json", "")
+    remote_config_source_gateway.get_remote_config.assert_any_call("repo", "engine_sca/engine_dependencies/ConfigTool.json", "")
+    remote_config_source_gateway.get_remote_config.assert_any_call("repo", "engine_sca/engine_dependencies/Exclusions.json", "")
     # tool_remote.get_variable.assert_called_with("pipeline_name")
     mock_handle_remote_config_patterns.assert_called_once()
     mock_dependencies_scan.return_value.process.assert_called_once()


### PR DESCRIPTION
## Description

A flag is added to select the platform on which the remote configuration repository is hosted

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
