### PR TITLE
fix: only add certs when folder exists

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -120,8 +120,12 @@ RUN apt-get update && \
     temurin-21-jdk && \
     rm -rf /var/lib/apt/lists/*
 
-RUN CERT_FILE=$(python3 -m certifi) \
-    && cat /tmp/certificates/* >> $CERT_FILE \
-    && echo "Certificates added to $CERT_FILE"
+RUN if [ -d /tmp/certificates ]; then \
+    CERT_FILE=$(python3 -m certifi) && \
+    cat /tmp/certificates/* >> "$CERT_FILE" && \
+    echo "Certificates added to $CERT_FILE"; \
+    else \
+    echo "/tmp/certificates does not exist, skipping certificate addition."; \
+    fi
 
 CMD ["sh", "-c", "dockerd & while ! docker info > /dev/null 2>&1; do sleep 1; done; sh"]


### PR DESCRIPTION
## Fix
only add certs when folder exists in the docker image

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
