### PR TITLE
fix: apply integer rate limit only

### DIFF
--- a/tools/devsecops_engine_tools/engine_dast/src/domain/model/api_config.py
+++ b/tools/devsecops_engine_tools/engine_dast/src/domain/model/api_config.py
@@ -4,11 +4,14 @@ from devsecops_engine_tools.engine_dast.src.domain.model.api_operation import Ap
 class ApiConfig():
     def __init__(self, api_data: dict):
         try:
+            try: rl = int(api_data.get("rate_limit"))
+            except: rl = 150
+
             self.target_type: str = "API"
             self.endpoint: str = api_data["endpoint"]
             self.operations: "List[ApiOperation]" = api_data["operations"]
             self.concurrency: Optional[int] = None
-            self.rate_limit: Optional[int] = api_data.get("rate_limit", 150)
+            self.rate_limit: Optional[int] = rl
             self.response_size: Optional[int] = None
             self.bulk_size: Optional[int] = None
             self.timeout: Optional[int] = None

--- a/tools/devsecops_engine_tools/engine_dast/src/domain/model/wa_config.py
+++ b/tools/devsecops_engine_tools/engine_dast/src/domain/model/wa_config.py
@@ -2,11 +2,14 @@ from typing import Optional
 
 class WaConfig:
     def __init__(self, data: dict, authentication_gateway):
+        try: rl = int(data.get("rate_limit"))
+        except: rl = 150
+
         self.target_type: str = "WA"
         self.url: str = data["endpoint"]
         self.data: dict = data["data"]
         self.concurrency: Optional[int] = None
-        self.rate_limit: Optional[int] = data.get("rate_limit", 150)
+        self.rate_limit: Optional[int] = rl
         self.response_size: Optional[int] = None
         self.bulk_size: Optional[int] = None
         self.timeout: Optional[int] = None


### PR DESCRIPTION
## Fix
apply integer rate limit only to prevent failures in nuclei command execution

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
