### PR TITLE
fix(kics): correct query list generation in engine_iac when using kics

### DIFF
--- a/tools/devsecops_engine_tools/engine_sast/engine_iac/src/infrastructure/driven_adapters/kics/kics_tool.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_iac/src/infrastructure/driven_adapters/kics/kics_tool.py
@@ -153,9 +153,13 @@ class KicsTool(ToolGateway):
         queries,
     ):
         folders = ','.join(folders_to_scan)
-        queries = ','.join(
-            uuid for query in queries for uuid in list(query.values())[0]
-            ) if queries else ""
+        queries_flat = [
+            uuid
+            for query in queries
+            for uuid in list(query.values())[0]
+            if uuid
+        ] if queries else []
+        queries = ','.join(queries_flat)
         mapped_platforms = [ 
                             self.scan_type_platform_mapping.get(platform.lower(), platform) 
                             for platform in platform_to_scan ] if platform_to_scan != ["all"] else list(self.scan_type_platform_mapping.values())


### PR DESCRIPTION
## Description

This Pull Request fixes the incorrect construction of the query list when using the engine_iac module with the kics tool. The generated command previously included an invalid or incomplete list of queries, which could affect scan accuracy or cause execution issues.

### Fix 
closes #421 
*How does someone fix the issue in code and/or in runtime?* Yes

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
