### PR TITLE
fix(kics): search folder to exclude

### DIFF
--- a/example_remote_config_local/engine_sast/engine_iac/ConfigTool.json
+++ b/example_remote_config_local/engine_sast/engine_iac/ConfigTool.json
@@ -740,7 +740,7 @@
         "CLI_VERSION":"2.1.5",
         "PATH_KICS": "kics/bin/kics",
         "DOWNLOAD_KICS_ASSETS": false,
-        "EXCLUDE_PATHS": ["path_to_exclude_file_folder_1", "path_to_exclude_file_folder_2"],
+        "EXCLUDE_PATHS": ["name_folder_to_exclude_1", "name_folder_to_exclude_2"],
         "RULES":{
             "RULES_OPENAPI":{
                 "CKV_OPENAPI_1":{

--- a/tools/devsecops_engine_tools/engine_sast/engine_iac/src/infrastructure/driven_adapters/kics/kics_tool.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_iac/src/infrastructure/driven_adapters/kics/kics_tool.py
@@ -186,7 +186,19 @@ class KicsTool(ToolGateway):
         except Exception as e:
             logger.error(f"Error writing queries file: {e}")
 
-    
+    def _find_exclude_paths(self, base_path, exclude_paths):
+        exclude_dirs = []
+        try:
+            for root, dirs, files in os.walk(base_path):
+                for dir_name in dirs:
+                    if dir_name.lower() in exclude_paths:
+                        rel_path = os.path.relpath(os.path.join(root, dir_name), base_path)
+                        exclude_dirs.append(rel_path)
+            return exclude_dirs
+        except Exception as e: 
+            logger.error(f"Error finding exclude paths: {e}")
+            return []
+        
     def _execute_kics(
         self,
         folders_to_scan,
@@ -209,7 +221,7 @@ class KicsTool(ToolGateway):
             self.scan_type_platform_mapping.get(platform.lower(), platform) 
             for platform in platform_to_scan ] if platform_to_scan != ["all"] else list(self.scan_type_platform_mapping.values())
         platforms = ','.join(mapped_platforms)
-        exclude_paths_str = ",".join([path.strip().replace("'", "").replace('"', "") for path in exclude_paths]) if exclude_paths else ""
+        exclude_paths_str = ",".join(self._find_exclude_paths(folders, exclude_paths)) if exclude_paths else ""
         queries_path = f"{work_folder}\\kics-devsecops\\assets\\queries" if os_platform == "Windows" else f"{work_folder}/kics-devsecops/assets/queries"
 
         command = [
@@ -224,7 +236,7 @@ class KicsTool(ToolGateway):
             "-o", work_folder
         ]
         try:
-            subprocess.run(command, capture_output=True, text=True, cwd=work_folder)
+            subprocess.run(command, capture_output=True, text=True, cwd=folders)
         except subprocess.CalledProcessError as e:
             logger.error(f"Error during KICS execution: {e}")
             return []


### PR DESCRIPTION
## Description

implement a function to identify the paths of the list of exclude paths and use in the kics scan to avoid incorrect reports

### Fix
*How does someone fix the issue in code and/or in runtime?* yes #428 

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
