### PR TITLE
fix(engine_risk): the filter_duplicated function is removed

### DIFF
--- a/tools/devsecops_engine_tools/engine_risk/src/domain/usecases/handle_filters.py
+++ b/tools/devsecops_engine_tools/engine_risk/src/domain/usecases/handle_filters.py
@@ -7,45 +7,6 @@ class HandleFilters:
         self._get_priority_vulnerability(active_findings)
         return active_findings
 
-    def filter_duplicated(self, findings):
-        unique_findings = []
-        findings_map = {}
-
-        for finding in findings:
-            key = (finding.where, tuple(finding.id), finding.vuln_id_from_tool)
-            if key in findings_map:
-                existing_finding = findings_map[key]
-                combined_services = existing_finding.service.split() + [
-                    s
-                    for s in finding.service.split()
-                    if s not in existing_finding.service.split()
-                ]
-                combined_vm_ids = existing_finding.vm_id.split() + [
-                    vm
-                    for vm in finding.vm_id.split()
-                    if vm not in existing_finding.vm_id.split()
-                ]
-                combined_vm_id_urls = existing_finding.vm_id_url.split() + [
-                    vm_url
-                    for vm_url in finding.vm_id_url.split()
-                    if vm_url not in existing_finding.vm_id_url.split()
-                ]
-                if finding.age >= existing_finding.age:
-                    new_finding = copy.deepcopy(finding)
-                    new_finding.service = " ".join(combined_services)
-                    new_finding.vm_id = " ".join(combined_vm_ids)
-                    new_finding.vm_id_url = " ".join(combined_vm_id_urls)
-                    findings_map[key] = new_finding
-                else:
-                    existing_finding.service = " ".join(combined_services)
-                    existing_finding.vm_id = " ".join(combined_vm_ids)
-                    existing_finding.vm_id_url = " ".join(combined_vm_id_urls)
-            else:
-                findings_map[key] = copy.deepcopy(finding)
-
-        unique_findings = list(findings_map.values())
-        return unique_findings
-
     def filter_tags_days(self, devops_platform_gateway, remote_config, findings):
         tag_exclusion_days = remote_config["TAG_EXCLUSION_DAYS"]
         filtered_findings = []

--- a/tools/devsecops_engine_tools/engine_risk/src/infrastructure/entry_points/entry_point_risk.py
+++ b/tools/devsecops_engine_tools/engine_risk/src/infrastructure/entry_points/entry_point_risk.py
@@ -52,10 +52,8 @@ def init_engine_risk(
 
     active_findings = handle_filters.filter(findings)
 
-    unique_findings = handle_filters.filter_duplicated(active_findings)
-
     filtered_findings, len_tag_filtered = handle_filters.filter_tags_days(
-        devops_platform_gateway, remote_config, unique_findings
+        devops_platform_gateway, remote_config, active_findings
     )
 
     data_added = AddData(add_epss_gateway, filtered_findings).process()

--- a/tools/devsecops_engine_tools/engine_risk/test/domain/usecases/test_handle_filters.py
+++ b/tools/devsecops_engine_tools/engine_risk/test/domain/usecases/test_handle_filters.py
@@ -58,41 +58,6 @@ class TestHandleFilters(unittest.TestCase):
 
         assert len(result) == 2
 
-    def test_filter_duplicated(self):
-        findings = [
-            Report(
-                id=["CVE-2021-1234"],
-                date="21022024",
-                status="stat2",
-                where="path2",
-                tags=["tag1"],
-                severity="low",
-                active=True,
-            ),
-            Report(
-                id=["CVE-2021-1234"],
-                date="21022024",
-                status="stat2",
-                where="path2",
-                tags=["tag2"],
-                severity="low",
-                active=None,
-            ),
-            Report(
-                id=["vuln_id"],
-                date="21022024",
-                status="stat3",
-                where="path3",
-                tags=["tag3"],
-                severity="info",
-                active=True,
-            ),
-        ]
-
-        result = self.handle_filters.filter_duplicated(findings)
-
-        assert len(result) == 2
-
     def test_filter_tags_days(self):
         remote_config = {"TAG_EXCLUSION_DAYS": {"tag1": 5, "tag2": 10}}
         findings = [

--- a/tools/devsecops_engine_tools/engine_risk/test/infrastructure/entry_points/test_entry_point_risk.py
+++ b/tools/devsecops_engine_tools/engine_risk/test/infrastructure/entry_points/test_entry_point_risk.py
@@ -30,7 +30,6 @@ def test_init_engine_risk(
     # Configurar la instancia de HandleFilters correctamente
     instance_handle_filters = mock_handle_filters.return_value
     instance_handle_filters.filter.return_value = findings
-    instance_handle_filters.filter_duplicated.return_value = findings
     instance_handle_filters.filter_tags_days.return_value = ("filtered_findings", 0)
 
     # Configurar la instancia de GetExclusions correctamente
@@ -50,7 +49,6 @@ def test_init_engine_risk(
 
     assert mock_remote_config_source_gateway.get_remote_config.call_count == 2
     instance_handle_filters.filter.assert_called_once_with(findings)
-    instance_handle_filters.filter_duplicated.assert_called_once()
     instance_handle_filters.filter_tags_days.assert_called_once()
     mock_add_data.assert_called_once()
     mock_get_exclusions.assert_called_once()


### PR DESCRIPTION
## Description

The filter_duplicated function in the Engine Risk module is unable to differentiate between findings with the Engine_iac tag. For example, if multiple secrets are found in the same file, Engine_risk treats them as one when trying to exclude by tag, which leads to an incorrect calculation of the remediation rate.

### Fix
the filter_duplicated function is removed

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
