### PR TITLE
feat: scanning compressed image files with trivy

### DIFF
--- a/tools/devsecops_engine_tools/engine_sca/engine_container/src/domain/model/gateways/tool_gateway.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/src/domain/model/gateways/tool_gateway.py
@@ -3,5 +3,5 @@ from abc import ABCMeta, abstractmethod
 
 class ToolGateway(metaclass=ABCMeta):
     @abstractmethod
-    def run_tool_container_sca(self, dict_args, secret_tool, token_engine_container, scan_image, release, base_image, exclusions, generate_sbom):
+    def run_tool_container_sca(self, dict_args, secret_tool, token_engine_container, scan_image, release, base_image, exclusions, generate_sbom, is_compressed_file=False):
         "run tool container sca"

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/src/domain/usecases/container_sca_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/src/domain/usecases/container_sca_scan.py
@@ -39,6 +39,7 @@ class ContainerScaScan:
         self.context = context
 
     def _is_compressed_file(self, image_to_scan):
+        """Check if the input is a compressed file (tar, tar.gz, etc.)"""
         return any(
             image_to_scan.lower().endswith(ext) 
             for ext in ['.tar', '.tar.gz', '.tgz', '.tar.bz2', '.tar.xz']

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/src/domain/usecases/container_sca_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/src/domain/usecases/container_sca_scan.py
@@ -38,6 +38,12 @@ class ContainerScaScan:
         self.pipeline_name = pipeline_name
         self.context = context
 
+    def _is_compressed_file(self, image_to_scan):
+        return any(
+            image_to_scan.lower().endswith(ext) 
+            for ext in ['.tar', '.tar.gz', '.tgz', '.tar.bz2', '.tar.xz']
+        )
+
     def process(self):
         """
         Process SCA scanning.
@@ -47,51 +53,72 @@ class ContainerScaScan:
         """
         base_image = None
         image_scanned = None
-        matching_image = self._get_image(self.image_to_scan)
-        if self.remote_config["GET_IMAGE_BASE"]["ENABLED"]:
-            base_image = self._get_base_image(matching_image)
-        if self.remote_config["VALIDATE_BASE_IMAGE_DATE"][
-            "ENABLED"
-        ] and not self.exclusions.get(self.pipeline_name, {}).get(
-            "VALIDATE_BASE_IMAGE_DATE"
-        ):
-            self._validate_base_image_date(
-                matching_image,
-                self.remote_config["VALIDATE_BASE_IMAGE_DATE"]["REFERENCE_IMAGE_DATE"],
-            )
-        if self.remote_config["BLACK_LIST_BASE_IMAGE"][
-            "ENABLED"
-        ] and not self.exclusions.get(self.pipeline_name, {}).get(
-            "BLACK_LIST_BASE_IMAGE"
-        ):
-            self._validate_black_list_base_image(
-                base_image, self.remote_config["BLACK_LIST_BASE_IMAGE"]["BLACK_LIST"]
-            )
-
         sbom_components = None
+        
+        is_compressed_file = self._is_compressed_file(self.image_to_scan)
+        
+        if is_compressed_file:
+            if not os.path.exists(self.image_to_scan):
+                print(f"Compressed file not found: {self.image_to_scan}. Tool skipped.")
+                return image_scanned, base_image, sbom_components
+                
+            matching_image = None
+            image_name = self.image_to_scan
+            print(f"Processing compressed file: {image_name}")
+        else:
+            matching_image = self._get_image(self.image_to_scan)
+            if not matching_image:
+                print(f"'Not image found for {self.image_to_scan}'. Tool skipped.")
+                return image_scanned, base_image, sbom_components
+                
+            image_name = matching_image.tags[0]
+            
+            if self.remote_config["GET_IMAGE_BASE"]["ENABLED"]:
+                base_image = self._get_base_image(matching_image)
+            if self.remote_config["VALIDATE_BASE_IMAGE_DATE"][
+                "ENABLED"
+            ] and not self.exclusions.get(self.pipeline_name, {}).get(
+                "VALIDATE_BASE_IMAGE_DATE"
+            ):
+                self._validate_base_image_date(
+                    matching_image,
+                    self.remote_config["VALIDATE_BASE_IMAGE_DATE"]["REFERENCE_IMAGE_DATE"],
+                )
+            if self.remote_config["BLACK_LIST_BASE_IMAGE"][
+                "ENABLED"
+            ] and not self.exclusions.get(self.pipeline_name, {}).get(
+                "BLACK_LIST_BASE_IMAGE"
+            ):
+                self._validate_black_list_base_image(
+                    base_image, self.remote_config["BLACK_LIST_BASE_IMAGE"]["BLACK_LIST"]
+                )
+
         generate_sbom = self.remote_config["SBOM"]["ENABLED"] and any(
             branch in str(self.branch)
             for branch in self.remote_config["SBOM"]["BRANCH_FILTER"]
         )
-        if matching_image:
-            image_name = matching_image.tags[0]
-            result_file = image_name.replace("/", "_") + "_scan_result.json"
-            if image_name in self._get_images_already_scanned():
-                print(f"The image {image_name} has already been scanned previously.")
-                return image_scanned, base_image, sbom_components
-            image_scanned, sbom_components = self.tool_run.run_tool_container_sca(
-                self.remote_config,
-                self.secret_tool,
-                self.token_engine_container,
-                image_name,
-                result_file,
-                base_image,
-                self.exclusions,
-                generate_sbom,
-            )
+
+        result_file = image_name.replace("/", "_").replace(".", "_") + "_scan_result.json"
+        
+        if not is_compressed_file and image_name in self._get_images_already_scanned():
+            print(f"The image {image_name} has already been scanned previously.")
+            return image_scanned, base_image, sbom_components
+            
+        image_scanned, sbom_components = self.tool_run.run_tool_container_sca(
+            self.remote_config,
+            self.secret_tool,
+            self.token_engine_container,
+            image_name,
+            result_file,
+            base_image,
+            self.exclusions,
+            generate_sbom,
+            is_compressed_file,
+        )
+        
+        if not is_compressed_file:
             self._set_image_scanned(image_name)
-        else:
-            print(f"'Not image found for {self.image_to_scan}'. Tool skipped.")
+            
         return image_scanned, base_image, sbom_components
 
     def deseralizator(self, image_scanned):

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/src/infrastructure/driven_adapters/prisma_cloud/prisma_cloud_manager_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/src/infrastructure/driven_adapters/prisma_cloud/prisma_cloud_manager_scan.py
@@ -171,8 +171,12 @@ class PrismaCloudManagerScan(ToolGateway):
             raise ValueError("The string is not properly formatted. Make sure it contains a ':'.")
         
     def run_tool_container_sca(
-        self, remoteconfig, secret_tool, token_engine_container, image_name, result_file, base_image, exclusions, generate_sbom
+        self, remoteconfig, secret_tool, token_engine_container, image_name, result_file, base_image, exclusions, generate_sbom, is_compressed_file=False
     ):
+        if is_compressed_file:
+            logger.warning("Prisma Cloud does not support compressed file scanning. Skipping.")
+            return "", None
+            
         prisma_key = (
             f"{secret_tool['access_prisma']}:{secret_tool['token_prisma']}" if secret_tool else token_engine_container
         )

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/src/infrastructure/driven_adapters/trivy_tool/trivy_manager_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/src/infrastructure/driven_adapters/trivy_tool/trivy_manager_scan.py
@@ -62,7 +62,7 @@ class TrivyScan(ToolGateway):
             except Exception as e:
                 logger.error(f"Error installing trivy: {e}")
 
-    def scan_image(self, prefix, image_name, result_file, base_image):
+    def scan_image(self, prefix, image_name, result_file, base_image, is_compressed_file=False):
         command = [
             prefix,
             "--scanners",
@@ -72,7 +72,12 @@ class TrivyScan(ToolGateway):
             "-o",
             result_file,
         ]
-        command.extend(["--quiet", "image", image_name])
+        
+        if is_compressed_file:
+            command.extend(["--quiet", "image", "--input", image_name])
+        else:
+            command.extend(["--quiet", "image", image_name])
+            
         try:
             subprocess.run(
                 command,
@@ -88,7 +93,7 @@ class TrivyScan(ToolGateway):
         except Exception as e:
             logger.error(f"Error during image scan of {image_name}: {e}")
 
-    def _generate_sbom(self, prefix, image_name, remoteconfig):
+    def _generate_sbom(self, prefix, image_name, remoteconfig, is_compressed_file=False):
         result_sbom = f"{image_name.replace('/', '_')}_SBOM.json"
         command = [
             prefix,
@@ -98,7 +103,10 @@ class TrivyScan(ToolGateway):
             "--output",
             result_sbom
         ]
-        command.extend(["--quiet", image_name])
+        if is_compressed_file:
+            command.extend(["--quiet", "--input", image_name])
+        else:
+            command.extend(["--quiet", image_name])
         try:
             subprocess.run(
                 command,
@@ -114,7 +122,7 @@ class TrivyScan(ToolGateway):
         except Exception as e:
             logger.error(f"Error generating SBOM: {e}")
 
-    def run_tool_container_sca(self, remoteconfig, secret_tool, token_engine_container, image_name, result_file, base_image, exclusions, generate_sbom):
+    def run_tool_container_sca(self, remoteconfig, secret_tool, token_engine_container, image_name, result_file, base_image, exclusions, generate_sbom, is_compressed_file=False):
         trivy_version = remoteconfig["TRIVY"]["TRIVY_VERSION"]
         os_platform = platform.system()
         arch_platform = platform.architecture()[0]
@@ -136,9 +144,9 @@ class TrivyScan(ToolGateway):
             return None
 
         image_scanned = (
-            self.scan_image(command_prefix, image_name, result_file, base_image)
+            self.scan_image(command_prefix, image_name, result_file, base_image, is_compressed_file)
         )
         if generate_sbom:
-            sbom_components = self._generate_sbom(command_prefix, image_name, remoteconfig)
+            sbom_components = self._generate_sbom(command_prefix, image_name, remoteconfig, is_compressed_file)
 
         return image_scanned, sbom_components

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/test/domain/usescases/test_container_sca_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/test/domain/usescases/test_container_sca_scan.py
@@ -128,6 +128,7 @@ def test_process_image_not_already_scanned(container_sca_scan):
         "base_image:latest",
         {'exclusions': 'exclusions'},
         False,
+        False,
     )
     container_sca_scan._set_image_scanned.assert_called_once_with("my_image:1234")
 
@@ -176,3 +177,84 @@ def test_validate_black_list_base_image_no_base_image(container_sca_scan):
 
     container_sca_scan.tool_images.validate_black_list_base_image.assert_not_called()
     assert result is True
+
+
+def test_is_compressed_file_tar(container_sca_scan):
+    """Test detection of .tar files"""
+    assert container_sca_scan._is_compressed_file("/path/to/image.tar") is True
+
+
+def test_is_compressed_file_tar_gz(container_sca_scan):
+    """Test detection of .tar.gz files"""
+    assert container_sca_scan._is_compressed_file("/path/to/image.tar.gz") is True
+
+
+def test_is_compressed_file_tgz(container_sca_scan):
+    """Test detection of .tgz files"""
+    assert container_sca_scan._is_compressed_file("/path/to/image.tgz") is True
+
+
+def test_is_compressed_file_tar_bz2(container_sca_scan):
+    """Test detection of .tar.bz2 files"""
+    assert container_sca_scan._is_compressed_file("/path/to/image.tar.bz2") is True
+
+
+def test_is_compressed_file_tar_xz(container_sca_scan):
+    """Test detection of .tar.xz files"""
+    assert container_sca_scan._is_compressed_file("/path/to/image.tar.xz") is True
+
+
+def test_is_compressed_file_not_compressed(container_sca_scan):
+    """Test that regular image names are not detected as compressed files"""
+    assert container_sca_scan._is_compressed_file("nginx:latest") is False
+
+
+def test_is_compressed_file_non_existent(container_sca_scan):
+    """Test that paths with compressed extensions are detected even if they don't exist"""
+    assert container_sca_scan._is_compressed_file("/non/existent/path.tar") is True
+
+
+@patch('os.path.exists')
+def test_process_compressed_file_success(mock_exists, container_sca_scan):
+    """Test processing of compressed file"""
+    mock_exists.return_value = True
+    container_sca_scan.image_to_scan = "/path/to/image.tar.gz"
+    container_sca_scan.tool_run = MagicMock()
+    container_sca_scan._get_images_already_scanned = MagicMock(return_value=[])
+    component_list = [Component("component1", "version1")]
+    container_sca_scan.tool_run.run_tool_container_sca.return_value = (
+        "result.json", 
+        component_list
+    )
+    
+    image_scanned, base_image, components = container_sca_scan.process()
+    
+    assert image_scanned == "result.json"
+    assert base_image is None
+    container_sca_scan.tool_run.run_tool_container_sca.assert_called_once_with(
+        container_sca_scan.remote_config,
+        container_sca_scan.secret_tool,
+        container_sca_scan.token_engine_container,
+        "/path/to/image.tar.gz",
+        "_path_to_image_tar_gz_scan_result.json",
+        None,
+        container_sca_scan.exclusions,
+        False,
+        True,  # is_compressed_file=True
+    )
+
+
+@patch('os.path.exists')
+def test_process_compressed_file_not_found(mock_exists, container_sca_scan):
+    """Test processing when compressed file doesn't exist"""
+    mock_exists.return_value = False
+    container_sca_scan.image_to_scan = "/path/to/nonexistent.tar.gz"
+    container_sca_scan.tool_run = MagicMock()
+    
+    image_scanned, base_image, components = container_sca_scan.process()
+    
+    assert image_scanned is None
+    assert base_image is None
+    assert components is None
+    # Verify that run_tool_container_sca was not called
+    container_sca_scan.tool_run.run_tool_container_sca.assert_not_called()

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/test/infrastructure/driven_adapters/prisma_cloud/test_prisma_cloud_manager_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/test/infrastructure/driven_adapters/prisma_cloud/test_prisma_cloud_manager_scan.py
@@ -342,3 +342,22 @@ def test_extra_colon_prisma_key():
     prisma_key = "your_access_key:your_secret_key:extra"
     with pytest.raises(ValueError, match="The string is not properly formatted. Make sure it contains a ':'."):
         scan_manager._split_prisma_token(prisma_key)
+
+
+def test_run_tool_container_sca_compressed_file():
+    """Test that Prisma Cloud returns None for compressed files with proper warning"""
+    scan_manager = PrismaCloudManagerScan()
+    
+    result = scan_manager.run_tool_container_sca(
+        remoteconfig={},
+        secret_tool=None,
+        token_engine_container=None,
+        image_name="/path/to/image.tar.gz",
+        result_file="result.json",
+        base_image=None,
+        exclusions={},
+        generate_sbom=False,
+        is_compressed_file=True
+    )
+    
+    assert result == ("", None)

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/test/infrastructure/driven_adapters/trivy_tool/test_trivy_manager_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/test/infrastructure/driven_adapters/trivy_tool/test_trivy_manager_scan.py
@@ -233,3 +233,151 @@ def test_generate_sbom_failure(mock_logger, mock_subprocess_run):
     trivy_scan._generate_sbom(prefix, image_name, remoteconfig)
 
     mock_logger.error.assert_called_once_with("Error generating SBOM: Test exception")
+
+
+@patch('devsecops_engine_tools.engine_sca.engine_container.src.infrastructure.driven_adapters.trivy_tool.trivy_manager_scan.subprocess.run')
+def test_scan_image_compressed_file(mock_subprocess_run):
+    """Test scanning a compressed file"""
+    mock_subprocess_run.return_value = None
+
+    trivy_scan = TrivyScan()
+    prefix = "trivy"
+    image_name = "/path/to/image.tar.gz"
+    result_file = "result.json"
+    base_image = None
+
+    result = trivy_scan.scan_image(prefix, image_name, result_file, base_image, is_compressed_file=True)
+
+    assert result == result_file
+    mock_subprocess_run.assert_called_once_with(
+        [
+            prefix,
+            "--scanners",
+            "vuln",
+            "-f",
+            "json",
+            "-o",
+            result_file,
+            "--quiet",
+            "image",
+            "--input",
+            image_name,
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+@patch('devsecops_engine_tools.engine_sca.engine_container.src.infrastructure.driven_adapters.trivy_tool.trivy_manager_scan.subprocess.run')
+def test_scan_image_regular_image(mock_subprocess_run):
+    """Test scanning a regular Docker image"""
+    mock_subprocess_run.return_value = None
+
+    trivy_scan = TrivyScan()
+    prefix = "trivy"
+    image_name = "nginx:latest"
+    result_file = "result.json"
+    base_image = None
+
+    result = trivy_scan.scan_image(prefix, image_name, result_file, base_image, is_compressed_file=False)
+
+    assert result == result_file
+    mock_subprocess_run.assert_called_once_with(
+        [
+            prefix,
+            "--scanners",
+            "vuln",
+            "-f",
+            "json",
+            "-o",
+            result_file,
+            "--quiet",
+            "image",
+            image_name,
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+@patch('devsecops_engine_tools.engine_sca.engine_container.src.infrastructure.driven_adapters.trivy_tool.trivy_manager_scan.get_list_component')
+@patch('devsecops_engine_tools.engine_sca.engine_container.src.infrastructure.driven_adapters.trivy_tool.trivy_manager_scan.subprocess.run')
+def test_generate_sbom_compressed_file(mock_subprocess_run, mock_get_list_component):
+    """Test SBOM generation for compressed file"""
+    mock_subprocess_run.return_value = None
+    mock_get_list_component.return_value = ["component1", "component2"]
+
+    trivy_scan = TrivyScan()
+    prefix = "trivy"
+    image_name = "/path/to/image.tar.gz"
+    remoteconfig = {
+        "TRIVY": {
+            "SBOM_FORMAT": "json"
+        }
+    }
+
+    result = trivy_scan._generate_sbom(prefix, image_name, remoteconfig, is_compressed_file=True)
+
+    mock_subprocess_run.assert_called_once_with(
+        [
+            prefix,
+            "image",
+            "--format",
+            "json",
+            "--output",
+            f"{image_name.replace('/', '_')}_SBOM.json",
+            "--quiet",
+            "--input",
+            image_name,
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    mock_get_list_component.assert_called_once_with(f"{image_name.replace('/', '_')}_SBOM.json", "json")
+    assert result, ["component1", "component2"]
+
+
+@patch('devsecops_engine_tools.engine_sca.engine_container.src.infrastructure.driven_adapters.trivy_tool.trivy_manager_scan.platform.system')
+@patch('devsecops_engine_tools.engine_sca.engine_container.src.infrastructure.driven_adapters.trivy_tool.trivy_manager_scan.TrivyScan.install_tool')
+@patch('devsecops_engine_tools.engine_sca.engine_container.src.infrastructure.driven_adapters.trivy_tool.trivy_manager_scan.TrivyScan.scan_image')
+@patch('devsecops_engine_tools.engine_sca.engine_container.src.infrastructure.driven_adapters.trivy_tool.trivy_manager_scan.TrivyScan._generate_sbom')
+def test_run_tool_container_sca_compressed_file(mock_generate_sbom, mock_scan_image, mock_install_tool, mock_platform_system):
+    """Test running SCA tool with compressed file"""
+    mock_platform_system.return_value = "Linux"
+    mock_install_tool.return_value = "trivy"
+    mock_scan_image.return_value = "result.json"
+    mock_generate_sbom.return_value = ["component1"]
+
+    trivy_scan = TrivyScan()
+    remoteconfig = {
+        "TRIVY": {
+            "TRIVY_VERSION": "0.48.1",
+            "SBOM_FORMAT": "json"
+        }
+    }
+
+    result = trivy_scan.run_tool_container_sca(
+        remoteconfig=remoteconfig,
+        secret_tool=None,
+        token_engine_container=None,
+        image_name="/path/to/image.tar.gz",
+        result_file="result.json",
+        base_image=None,
+        exclusions={},
+        generate_sbom=True,
+        is_compressed_file=True
+    )
+
+    mock_scan_image.assert_called_once_with(
+        "trivy", "/path/to/image.tar.gz", "result.json", None, True
+    )
+    mock_generate_sbom.assert_called_once_with(
+        "trivy", "/path/to/image.tar.gz", remoteconfig, True
+    )
+    assert result == ("result.json", ["component1"])


### PR DESCRIPTION
## Description

Support for scanning files generated by saving images with container engines has been enabled with the trivy tool.

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
