### PR TITLE
feat(engine_risk): add runtime tag exclusions days

### DIFF
--- a/docs/ENVIROMENT_CONFIGURATION.md
+++ b/docs/ENVIROMENT_CONFIGURATION.md
@@ -123,7 +123,9 @@ PYTHONPATH=tools/
                 "RUNNER_WORKSPACE": "",
                 "RUNNER_OS": "Linux",
                 "GITHUB_SOURCE_CODE_MANAGEMENT_URI": "https://github.com/Owner/repository",
-                "RUNNER_TOOL_CACHE": ""
+                "RUNNER_TOOL_CACHE": "",
+                //engine risk
+                "TAG_EXCLUSION_DAYS": "{\"tag1\": 5, \"tag2\": 10}"
             },
             "justMyCode": true
         }

--- a/example_remote_config_local/engine_risk/ConfigTool.json
+++ b/example_remote_config_local/engine_risk/ConfigTool.json
@@ -46,6 +46,10 @@
         "max_age": 12,
         "epss_score": 100
     },
+    "RUNTIME_TAG_EXCLUSION_DAYS": {
+        "ENABLED": false,
+        "ERROR_ON_FAILED": false
+    },
     "TAG_EXCLUSION_DAYS": {
         "tag1": 10,
         "tag2": 20

--- a/tools/devsecops_engine_tools/engine_risk/src/domain/usecases/handle_filters.py
+++ b/tools/devsecops_engine_tools/engine_risk/src/domain/usecases/handle_filters.py
@@ -1,5 +1,6 @@
 import copy
-
+import os
+import json
 
 class HandleFilters:
     def filter(self, findings):
@@ -9,8 +10,27 @@ class HandleFilters:
 
     def filter_tags_days(self, devops_platform_gateway, remote_config, findings):
         tag_exclusion_days = remote_config["TAG_EXCLUSION_DAYS"]
+        runtime_tag_exclusion_days = remote_config["RUNTIME_TAG_EXCLUSION_DAYS"]
         filtered_findings = []
         filtered = 0
+
+        if runtime_tag_exclusion_days['ENABLED']:
+
+            def print_error(devops_platform_gateway, tag_exclusion_days_str, message):
+                runtime_message_set = f"Runtime Tag Exclusions days set \"{tag_exclusion_days_str}\". {message}"
+                if runtime_tag_exclusion_days['ERROR_ON_FAILED']:
+                    print(devops_platform_gateway.message("error", runtime_message_set))
+                else:
+                    print(devops_platform_gateway.message("info", f"{runtime_message_set}. Using default TAG_EXCLUSION_DAYS"))
+
+            tag_exclusion_days_str = os.environ.get('TAG_EXCLUSION_DAYS')
+            if tag_exclusion_days_str and tag_exclusion_days_str.strip():
+                try:
+                    tag_exclusion_days = json.loads(tag_exclusion_days_str)
+                except:
+                    print_error(devops_platform_gateway, tag_exclusion_days_str, "Parse Error")
+            else:
+                print_error(devops_platform_gateway, tag_exclusion_days_str, "Invalid Env Var")
 
         for finding in findings:
             exclude = False

--- a/tools/devsecops_engine_tools/engine_risk/test/domain/usecases/test_handle_filters.py
+++ b/tools/devsecops_engine_tools/engine_risk/test/domain/usecases/test_handle_filters.py
@@ -1,3 +1,5 @@
+import json
+import os
 import unittest
 from unittest.mock import MagicMock, patch
 from devsecops_engine_tools.engine_risk.src.domain.usecases.handle_filters import (
@@ -59,7 +61,13 @@ class TestHandleFilters(unittest.TestCase):
         assert len(result) == 2
 
     def test_filter_tags_days(self):
-        remote_config = {"TAG_EXCLUSION_DAYS": {"tag1": 5, "tag2": 10}}
+        remote_config = {
+            "RUNTIME_TAG_EXCLUSION_DAYS": {
+                "ENABLED": False,
+                "ERROR_ON_FAILED": False
+            },
+            "TAG_EXCLUSION_DAYS": {"tag1": 5, "tag2": 10}
+        }
         findings = [
             Report(
                 id=["CVE-2021-1234"],
@@ -80,6 +88,59 @@ class TestHandleFilters(unittest.TestCase):
                 severity="low",
                 active=None,
                 age=11,
+            ),
+            Report(
+                id=["vuln_id"],
+                date="21022024",
+                status="stat3",
+                where="path3",
+                tags=["tag3"],
+                severity="info",
+                active=True,
+                age=5,
+            ),
+        ]
+        devops_platform_gateway = MagicMock()
+
+        result = self.handle_filters.filter_tags_days(
+            devops_platform_gateway, remote_config, findings
+        )
+
+        devops_platform_gateway.message.assert_called_once()
+        assert len(result) == 2
+
+    def test_filter_tags_days_runtime(self):
+        remote_config = {
+            "RUNTIME_TAG_EXCLUSION_DAYS": {
+                "ENABLED": True,
+                "ERROR_ON_FAILED": True
+            },
+            "TAG_EXCLUSION_DAYS": {"tag1": 5, "tag2": 10}
+        }
+        runtime_exclusions_days = {"tag1": 7, "tag2": 14}
+        json_str = json.dumps(runtime_exclusions_days)
+        os.environ["TAG_EXCLUSION_DAYS"] = json_str
+
+        findings = [
+            Report(
+                id=["CVE-2021-1234"],
+                date="21022024",
+                status="stat2",
+                where="path2",
+                tags=["tag1"],
+                severity="low",
+                active=True,
+                age=6,
+            ),
+            Report(
+                id=["CVE-2021-1234"],
+                date="21022024",
+                status="stat2",
+                where="path2",
+                tags=["tag2"],
+                severity="low",
+                active=True,
+                age=15,
             ),
             Report(
                 id=["vuln_id"],


### PR DESCRIPTION
## Description

Added new param in engine risk remote config  "RUNTIME_TAG_EXCLUSION_DAYS", in order to change tag exclusions days dinamically, depending on TAG_EXCLUSION_DAYS environment variable set on running platform. In case error with value set on TAG_EXCLUSION_DAYS, can be printed info or error message dependening on "ERROR_ON_FAILED" is set false or true

### Fix
*In Case error is presented by new config RUNTIME_TAG_EXCLUSION_DAYS make sure it is set false to continue with usual flow

## Checklist:

- [X] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
