### PR TITLE
fix: adjust driven adapter kics

### DIFF
--- a/tools/devsecops_engine_tools/engine_sast/engine_iac/src/infrastructure/driven_adapters/kics/kics_tool.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_iac/src/infrastructure/driven_adapters/kics/kics_tool.py
@@ -106,7 +106,7 @@ class KicsTool(ToolGateway):
                         check_name = query.get("query_name", ""),
                         check_class = query.get("category", ""),
                         severity = query.get("severity", ""),
-                        where = f"{file.get("file_name", "")} (line {file.get("line", "")}): expected value: {file.get("expected_value", "")}, actual value: {file.get("actual_value", "")}",
+                        where = f"{file.get('file_name', '')} (line {file.get('line', '')}) - expected value: {file.get('expected_value', '')}, actual value: {file.get('actual_value', '')}",
                         resource = file.get("issue_type", "unknown"),
                         description = query.get("description", ""),
                         module="engine_iac",


### PR DESCRIPTION
## Description

driven adapter kics has a bug in get_iac_context_from_results function

### Fix
*How does someone fix the issue in code and/or in runtime?* #458 

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
