### PR TITLE
fix(engine_risk): use print domain if it has content

### DIFF
--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/defect_dojo/defect_dojo.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/defect_dojo/defect_dojo.py
@@ -387,10 +387,16 @@ class DefectDojoPlatform(VulnerabilityManagementGateway):
 
             engagements = Engagement.get_engagements(request_is, request_active).results
 
+            print_domain = config_tool["VULNERABILITY_MANAGER"]["DEFECT_DOJO"][
+                "PRINT_DOMAIN"
+            ]
             host_dd = config_tool["VULNERABILITY_MANAGER"]["DEFECT_DOJO"][
                 "HOST_DEFECT_DOJO"
             ]
 
+            if print_domain:
+                host_dd = print_domain
+                
             for engagement in engagements:
                 engagement.vm_url = f"{host_dd}/engagement/{engagement.id}/finding/open"
 

--- a/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/defect_dojo/test_defect_dojo.py
+++ b/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/defect_dojo/test_defect_dojo.py
@@ -1043,6 +1043,7 @@ class TestDefectDojoPlatform(unittest.TestCase):
             "VULNERABILITY_MANAGER": {
                 "DEFECT_DOJO": {
                     "HOST_DEFECT_DOJO": "host_defect_dojo",
+                    "PRINT_DOMAIN": "",
                     "LIMITS_QUERY": 999,
                     "REIMPORT_SCAN": True,
                 }
@@ -1157,6 +1158,7 @@ class TestDefectDojoPlatform(unittest.TestCase):
             "VULNERABILITY_MANAGER": {
                 "DEFECT_DOJO": {
                     "HOST_DEFECT_DOJO": "http://defectdojo",
+                    "PRINT_DOMAIN": "",
                     "MAX_RETRIES_QUERY": 3,
                     "LIMITS_QUERY": 100,
                     "REIMPORT_SCAN": True,


### PR DESCRIPTION
## Description

The print_domain field is used when it contains content. This is so that when the engine_risk module is used, the correct host URL is printed.

### Fix
The print_domain field is utilized

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
