### PR TITLE
fix: kics command addition for iac scanning

### DIFF
--- a/ide_extension/vscode/devsecops/package.json
+++ b/ide_extension/vscode/devsecops/package.json
@@ -4,7 +4,7 @@
   "displayName": "DevSecOps Engine Tools",
   "publisher": "GrupoBancolombiaOSPO",
   "description": "",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/ide_extension/vscode/devsecops/src/infraestructure/drivenAdapter/IacScanner.ts
+++ b/ide_extension/vscode/devsecops/src/infraestructure/drivenAdapter/IacScanner.ts
@@ -47,7 +47,7 @@ export class IacScanner implements IScannerGateway {
           resolve(new ScannerRes(false, []));
         }, 600000);
 
-        const containerCommand = `${containerEnginePath} run --rm -v ${elementToScan}:/ms_artifact ${containerImageName}:${toolVersion} sh -c "devsecops-engine-tools --platform_devops local --remote_config_source local --remote_config_repo docker_default_remote_config --module engine_iac --tool checkov --folder_path /ms_artifact --context true"`;
+        const containerCommand = `${containerEnginePath} run --rm -v ${elementToScan}:/ms_artifact ${containerImageName}:${toolVersion} sh -c "devsecops-engine-tools --platform_devops local --remote_config_source local --remote_config_repo docker_default_remote_config --module engine_iac --tool ${iacTool}${iacTool === "kics" ? " --platform openapi" : ""} --folder_path /ms_artifact --context true"`;
 
         const childProcess = exec(containerCommand, (error, stdout, stderr) => {
           clearTimeout(timeout);


### PR DESCRIPTION
## Description

*Integration of kics tool command fro IaC sacanning.*

### Fix
*Include the deleted command for kics tool*

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
