### PR TITLE
fix: add file path to the engine dast test tag

### DIFF
--- a/example_remote_config_local/engine_dast/ConfigTool.json
+++ b/example_remote_config_local/engine_dast/ConfigTool.json
@@ -12,6 +12,7 @@
     },
     "MESSAGE_INFO_DAST": "If you have doubts, visit https://forum.example",
     "IGNORE_ERRORS": false,
+    "PRINT_API_CONFIG": true,
     "NUCLEI": {
         "VERSION": "3.3.5",
         "DOWNLOAD_URL": "https://github.com/projectdiscovery/nuclei/releases/download/",

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/defect_dojo/defect_dojo.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/defect_dojo/defect_dojo.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import re
+import os
 from devsecops_engine_tools.engine_core.src.domain.model.gateway.vulnerability_management_gateway import (
     VulnerabilityManagementGateway,
 )
@@ -114,6 +115,12 @@ class DefectDojoPlatform(VulnerabilityManagementGateway):
                         vulnerability_management.dict_args["image_to_scan"],
                     )
                     tags.append(match.group(1) if match else None)
+                if vulnerability_management.dict_args["module"] == "engine_dast":
+                    dast_file_path = vulnerability_management.dict_args["dast_file_path"]
+                    tag_suffix = os.path.splitext(os.path.basename(dast_file_path))[0].replace('-', '_')
+                    tags = [
+                        f"{vulnerability_management.dict_args['module']}_{tag_suffix}"
+                    ]
 
                 use_cmdb = vulnerability_management.config_tool[
                     "VULNERABILITY_MANAGER"
@@ -842,3 +849,4 @@ class DefectDojoPlatform(VulnerabilityManagementGateway):
             return finding.file_path
         else:
             return finding.file_path
+        


### PR DESCRIPTION
## Fix
Add file path to the dast engine test tag, since in cases where multiple files are handled, the findings from execution t-1 are closed in execution t.

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
