### PR TITLE
fix: add params to path in nuclei templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ log/
 twistcli
 trivy
 trivy_*.zip
-nuclei
 *scan_result.json
 jf
 jf.exe

--- a/tools/devsecops_engine_tools/engine_dast/src/infrastructure/driven_adapters/nuclei/nuclei_config.py
+++ b/tools/devsecops_engine_tools/engine_dast/src/infrastructure/driven_adapters/nuclei/nuclei_config.py
@@ -47,6 +47,9 @@ class NucleiConfig:
                 if "payload" in new_template_data["operation"]:
                     body = json_dumps(new_template_data["operation"]["payload"])
                     template_data["http"][0]["body"] = body
+                if "parm" in new_template_data["operation"]:
+                    parm_path = f"?{'&'.join([str(key) + '=' + str(value) for key, value in new_template_data['operation']['parm'].items()])}"
+                    template_data["http"][0]["path"] = f"{template_data['http'][0]['path']}{parm_path}"
 
         new_template_path = os.path.join(dest_folder, new_template_name)
 

--- a/tools/devsecops_engine_tools/engine_dast/src/infrastructure/driven_adapters/nuclei/nuclei_config.py
+++ b/tools/devsecops_engine_tools/engine_dast/src/infrastructure/driven_adapters/nuclei/nuclei_config.py
@@ -33,9 +33,12 @@ class NucleiConfig:
         with open(template_name, "r") as template_file:  # abrir  archivo
             template_data = self.yaml.load(template_file)
             if "http" in template_data:
+                parm_path = ""
+                if "parm" in new_template_data["operation"]:
+                    parm_path = f"?{'&'.join([str(key) + '=' + str(value) for key, value in new_template_data['operation']['parm'].items()])}" 
                 template_data["http"][0]["method"] = new_template_data["operation"]["method"]
                 template_data["http"][0]["path"] = [
-                    "{{BaseURL}}" + new_template_data["operation"]["path"]
+                    "{{BaseURL}}" + new_template_data["operation"]["path"] + parm_path
                 ]
                 if "headers" in new_template_data["operation"]:
                     if "headers" not in template_data["http"][0]:
@@ -47,9 +50,6 @@ class NucleiConfig:
                 if "payload" in new_template_data["operation"]:
                     body = json_dumps(new_template_data["operation"]["payload"])
                     template_data["http"][0]["body"] = body
-                if "parm" in new_template_data["operation"]:
-                    parm_path = f"?{'&'.join([str(key) + '=' + str(value) for key, value in new_template_data['operation']['parm'].items()])}"
-                    template_data["http"][0]["path"] = f"{template_data['http'][0]['path']}{parm_path}"
 
         new_template_path = os.path.join(dest_folder, new_template_name)
 


### PR DESCRIPTION
## Fix
add params to path in nuclei templates

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
