### PR TITLE
feat: update regex to identify file path in kics findings

### DIFF
--- a/ide_extension/vscode/devsecops/src/tree/results/finding/FindingItem.ts
+++ b/ide_extension/vscode/devsecops/src/tree/results/finding/FindingItem.ts
@@ -92,7 +92,7 @@ export class FindingItem extends vscode.TreeItem {
     if (pathMatch && pathMatch[1] && this.scanPath) {
       filePath = path.join(this.scanPath, pathMatch[1].substring(1));
     } else {
-      const genericPathMatch = where.match(/\/([/\w.-]+)(?::|$|\s)/);
+      const genericPathMatch = where.match(/([^\s/]+(?:\.[^\s/]+)*)\s*(?:\(line|$|\s)/);
       if (genericPathMatch && this.scanPath) {
         filePath = path.join(this.scanPath, genericPathMatch[1]);
       }


### PR DESCRIPTION
## Description

update regex to identify file path in kics findings

### Fix
*How does someone fix the issue in code and/or in runtime?* No

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
