### PR TITLE
fix(engine_secret): enable custom rules for Darwin Agent OS

### DIFF
--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/src/infrastructure/driven_adapters/trufflehog/trufflehog_run.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/src/infrastructure/driven_adapters/trufflehog/trufflehog_run.py
@@ -130,7 +130,7 @@ class TrufflehogRun(ToolGateway):
         command = f"{trufflehog_command} filesystem {path_folder} --include-paths {include_path} --exclude-paths {exclude_path} --no-verification --no-update --json"
         if enable_custom_rules:
             command = command.replace("--no-verification --no-update --json", f"--config {path}//rules//trufflehog//custom-rules.yaml --no-verification --no-update --json" if "Windows" in agent_os else
-                                      f"--config {path}/rules/trufflehog/custom-rules.yaml --no-verification --no-update --json" if "Linux" in agent_os else
+                                      f"--config {path}/rules/trufflehog/custom-rules.yaml --no-verification --no-update --json" if "Linux" or "Darwin" in agent_os else
                                       "--no-verification --no-update --json")
             
         result = subprocess.run(command, capture_output=True, shell=True, text=True, encoding='utf-8')
@@ -159,4 +159,5 @@ class TrufflehogRun(ToolGateway):
                 find["Mitigation"] = config_tool[tool]["RULES"][find["Id"]]["Mitigation"] if "SECRET_SCANNING" not in find["Id"] else "N.A"
                 json_str = json.dumps(find)
                 file.write(json_str + '\n')
+
         return findings, file_findings


### PR DESCRIPTION
## Description

Enable trufflehog custom rules download for Darwin Agent OS

### Fix
Currently if Engine Secret with trufflehog is run on a Mac Host custom rules are not downloaded, so if added anr or condition for "Darwin" so it has the same behavior as Linux

## Checklist:

- [X] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
