### PR TITLE
feat(engine): add custom repository name and pipeline name to engine 

### DIFF
--- a/tools/devsecops_engine_tools/engine_core/src/applications/runner_engine_core.py
+++ b/tools/devsecops_engine_tools/engine_core/src/applications/runner_engine_core.py
@@ -232,13 +232,6 @@ def get_inputs_from_cli(args):
         default="false",
         help="Enable or disable context creation. Applies to engine_iac, engine_container and engine_dependencies. Default is false."
     )
-    parser.add_argument(
-        "-repo",
-        "--repo_name",
-        type=str,
-        required=False,
-        help="Repository name, used when the repository name should not be taken from environment variable. Apply to kiuwan"
-    )
 
     TOOLS = {
         "engine_iac": ["checkov", "kics", "kubescape"],
@@ -282,7 +275,6 @@ def get_inputs_from_cli(args):
         "image_to_scan": args.image_to_scan,
         "dast_file_path": args.dast_file_path,
         "context": args.context,
-        "repo_name": args.repo_name
     }
 
 

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/azure/azure_devops.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/azure/azure_devops.py
@@ -102,11 +102,19 @@ class AzureDevops(DevopsPlatformGateway):
             "access_token": SystemVariables.System_AccessToken,
             "organization": SystemVariables.System_TeamFoundationCollectionUri,
             "project_name": SystemVariables.System_TeamProject,
-            "repository": CustomVariables.Repository_Name.value() or BuildVariables.Build_Repository_Name,
-            "pipeline_name": CustomVariables.Pipeline_Name.value() or (
-                BuildVariables.Build_DefinitionName
-                if SystemVariables.System_HostType.value() == "build"
-                else ReleaseVariables.Release_Definitionname
+            "repository": (
+                CustomVariables.Repository_Name 
+                if CustomVariables.Repository_Name.value() 
+                else BuildVariables.Build_Repository_Name
+            ),
+            "pipeline_name": (
+                CustomVariables.Pipeline_Name 
+                if CustomVariables.Pipeline_Name.value() 
+                else (
+                    BuildVariables.Build_DefinitionName
+                    if SystemVariables.System_HostType.value() == "build"
+                    else ReleaseVariables.Release_Definitionname
+                )
             ),
             "stage": SystemVariables.System_HostType,
             "path_directory": SystemVariables.System_DefaultWorkingDirectory,

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/azure/azure_devops.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/azure/azure_devops.py
@@ -8,7 +8,7 @@ from devsecops_engine_tools.engine_utilities.azuredevops.models.AzurePredefinedV
     ReleaseVariables,
     AgentVariables,
     VMVariables,
-    ApplicationVariables,
+    CustomVariables,
 )
 from devsecops_engine_tools.engine_utilities.azuredevops.infrastructure.azure_devops_api import (
     AzureDevopsApi,
@@ -101,8 +101,8 @@ class AzureDevops(DevopsPlatformGateway):
             "access_token": SystemVariables.System_AccessToken,
             "organization": SystemVariables.System_TeamFoundationCollectionUri,
             "project_name": SystemVariables.System_TeamProject,
-            "repository": BuildVariables.Build_Repository_Name,
-            "pipeline_name": (
+            "repository": CustomVariables.Repository_Name or BuildVariables.Build_Repository_Name,
+            "pipeline_name": CustomVariables.Pipeline_Name or (
                 BuildVariables.Build_DefinitionName
                 if SystemVariables.System_HostType.value() == "build"
                 else ReleaseVariables.Release_Definitionname
@@ -118,7 +118,7 @@ class AzureDevops(DevopsPlatformGateway):
             "vm_product_type_name": VMVariables.Vm_Product_Type_Name,
             "vm_product_name": VMVariables.Vm_Product_Name,
             "vm_product_description": VMVariables.Vm_Product_Description,
-            "build_task": ApplicationVariables.Application_Build_Task,
+            "build_task": CustomVariables.Build_Task,
         }
         try:
             return variable_map.get(variable).value()

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/azure/azure_devops.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/azure/azure_devops.py
@@ -59,7 +59,7 @@ class AzureDevops(DevopsPlatformGateway):
 
     def get_source_code_management_uri(self):
         try:
-            repository_variable = self.get_variable("repository").value()
+            repository_variable = self.get_variable("repository")
             source_code_management_uri = {
                 "tfsgit": (
                     f"{SystemVariables.System_TeamFoundationCollectionUri.value()}"

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/azure/azure_devops.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/azure/azure_devops.py
@@ -59,17 +59,18 @@ class AzureDevops(DevopsPlatformGateway):
 
     def get_source_code_management_uri(self):
         try:
+            repository_variable = self.get_variable("repository").value()
             source_code_management_uri = {
                 "tfsgit": (
                     f"{SystemVariables.System_TeamFoundationCollectionUri.value()}"
-                    f"{SystemVariables.System_TeamProject.value()}/_git/{BuildVariables.Build_Repository_Name.value()}"
+                    f"{SystemVariables.System_TeamProject.value()}/_git/{repository_variable}"
                 ).replace(" ", "%20"),
                 "github": (
-                    f"https://github.com/{BuildVariables.Build_Repository_Name.value()}"
+                    f"https://github.com/{repository_variable}"
                 ),
                 "git": (
                     f"{SystemVariables.System_TeamFoundationCollectionUri.value()}"
-                    f"{SystemVariables.System_TeamProject.value()}/_git/{BuildVariables.Build_Repository_Name.value()}"
+                    f"{SystemVariables.System_TeamProject.value()}/_git/{repository_variable}"
                 ).replace(" ", "%20")
             }
             return source_code_management_uri.get(BuildVariables.Build_Repository_Provider.value().lower())
@@ -101,8 +102,8 @@ class AzureDevops(DevopsPlatformGateway):
             "access_token": SystemVariables.System_AccessToken,
             "organization": SystemVariables.System_TeamFoundationCollectionUri,
             "project_name": SystemVariables.System_TeamProject,
-            "repository": CustomVariables.Repository_Name or BuildVariables.Build_Repository_Name,
-            "pipeline_name": CustomVariables.Pipeline_Name or (
+            "repository": CustomVariables.Repository_Name.value() or BuildVariables.Build_Repository_Name,
+            "pipeline_name": CustomVariables.Pipeline_Name.value() or (
                 BuildVariables.Build_DefinitionName
                 if SystemVariables.System_HostType.value() == "build"
                 else ReleaseVariables.Release_Definitionname

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/github/github_actions.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/github/github_actions.py
@@ -54,7 +54,7 @@ class GithubActions(DevopsPlatformGateway):
         return results.get(type)
 
     def get_source_code_management_uri(self):
-        return f"{SystemVariables.github_server_url.value()}/{self.get_variable("repository")}"
+        return f"{SystemVariables.github_server_url.value()}/{self.get_variable('repository')}"
 
     def get_base_compact_remote_config_url(self, remote_config_repo):
         github_repository = SystemVariables.github_repository.value()

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/github/github_actions.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/github/github_actions.py
@@ -54,7 +54,7 @@ class GithubActions(DevopsPlatformGateway):
         return results.get(type)
 
     def get_source_code_management_uri(self):
-        return f"{SystemVariables.github_server_url.value()}/{SystemVariables.github_repository.value()}"
+        return f"{SystemVariables.github_server_url.value()}/{self.get_variable("repository").value()}"
 
     def get_base_compact_remote_config_url(self, remote_config_repo):
         github_repository = SystemVariables.github_repository.value()
@@ -78,8 +78,8 @@ class GithubActions(DevopsPlatformGateway):
             "access_token": SystemVariables.github_access_token,
             "organization": f"{SystemVariables.github_server_url}/{SystemVariables.github_repository}",
             "project_name": SystemVariables.github_repository,
-            "repository": CustomVariables.Repository_Name or BuildVariables.github_repository,
-            "pipeline_name": CustomVariables.Pipeline_Name or (
+            "repository": CustomVariables.Repository_Name.value() or BuildVariables.github_repository,
+            "pipeline_name": CustomVariables.Pipeline_Name.value() or (
                 BuildVariables.github_workflow
                 if SystemVariables.github_job.value() == "build"
                 else ReleaseVariables.github_workflow

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/github/github_actions.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/github/github_actions.py
@@ -81,15 +81,15 @@ class GithubActions(DevopsPlatformGateway):
             "repository": (
                 CustomVariables.Repository_Name 
                 if CustomVariables.Repository_Name.value() 
-                else BuildVariables.Build_Repository_Name
+                else BuildVariables.github_repository
             ),
             "pipeline_name": (
                 CustomVariables.Pipeline_Name 
                 if CustomVariables.Pipeline_Name.value() 
                 else (
-                    BuildVariables.Build_DefinitionName
-                    if SystemVariables.System_HostType.value() == "build"
-                    else ReleaseVariables.Release_Definitionname
+                    BuildVariables.github_workflow
+                    if SystemVariables.github_job.value() == "build"
+                    else ReleaseVariables.github_workflow
                 )
             ),
             "stage": SystemVariables.github_job,

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/github/github_actions.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/github/github_actions.py
@@ -8,7 +8,7 @@ from devsecops_engine_tools.engine_utilities.github.models.GithubPredefinedVaria
     ReleaseVariables,
     AgentVariables,
     VMVariables,
-    ApplicationVariables
+    CustomVariables
 )
 from devsecops_engine_tools.engine_utilities.github.infrastructure.github_api import (
     GithubApi,
@@ -78,8 +78,8 @@ class GithubActions(DevopsPlatformGateway):
             "access_token": SystemVariables.github_access_token,
             "organization": f"{SystemVariables.github_server_url}/{SystemVariables.github_repository}",
             "project_name": SystemVariables.github_repository,
-            "repository": BuildVariables.github_repository,
-            "pipeline_name": (
+            "repository": CustomVariables.Repository_Name or BuildVariables.github_repository,
+            "pipeline_name": CustomVariables.Pipeline_Name or (
                 BuildVariables.github_workflow
                 if SystemVariables.github_job.value() == "build"
                 else ReleaseVariables.github_workflow
@@ -95,7 +95,7 @@ class GithubActions(DevopsPlatformGateway):
             "vm_product_type_name": VMVariables.Vm_Product_Type_Name,
             "vm_product_name": VMVariables.Vm_Product_Name,
             "vm_product_description": VMVariables.Vm_Product_Description,
-            "build_task":  ApplicationVariables.Application_Build_Task,
+            "build_task":  CustomVariables.Build_Task,
         }
         try:
             return variable_map.get(variable).value()

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/github/github_actions.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/github/github_actions.py
@@ -78,11 +78,19 @@ class GithubActions(DevopsPlatformGateway):
             "access_token": SystemVariables.github_access_token,
             "organization": f"{SystemVariables.github_server_url}/{SystemVariables.github_repository}",
             "project_name": SystemVariables.github_repository,
-            "repository": CustomVariables.Repository_Name.value() or BuildVariables.github_repository,
-            "pipeline_name": CustomVariables.Pipeline_Name.value() or (
-                BuildVariables.github_workflow
-                if SystemVariables.github_job.value() == "build"
-                else ReleaseVariables.github_workflow
+            "repository": (
+                CustomVariables.Repository_Name 
+                if CustomVariables.Repository_Name.value() 
+                else BuildVariables.Build_Repository_Name
+            ),
+            "pipeline_name": (
+                CustomVariables.Pipeline_Name 
+                if CustomVariables.Pipeline_Name.value() 
+                else (
+                    BuildVariables.Build_DefinitionName
+                    if SystemVariables.System_HostType.value() == "build"
+                    else ReleaseVariables.Release_Definitionname
+                )
             ),
             "stage": SystemVariables.github_job,
             "path_directory": SystemVariables.github_workspace,

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/github/github_actions.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/github/github_actions.py
@@ -54,7 +54,7 @@ class GithubActions(DevopsPlatformGateway):
         return results.get(type)
 
     def get_source_code_management_uri(self):
-        return f"{SystemVariables.github_server_url.value()}/{self.get_variable("repository").value()}"
+        return f"{SystemVariables.github_server_url.value()}/{self.get_variable("repository")}"
 
     def get_base_compact_remote_config_url(self, remote_config_repo):
         github_repository = SystemVariables.github_repository.value()

--- a/tools/devsecops_engine_tools/engine_core/test/applications/test_runner_engine_core.py
+++ b/tools/devsecops_engine_tools/engine_core/test/applications/test_runner_engine_core.py
@@ -110,7 +110,6 @@ def test_get_inputs_from_cli(mock_parse_args):
     mock_args.image_to_scan = "image"
     mock_args.dast_file_path = "dast_file_path"
     mock_args.context = "false"
-    mock_args.repo_name = None
     mock_args.token_engine_code=None
     
     # Mock the parse_args method
@@ -142,7 +141,6 @@ def test_get_inputs_from_cli(mock_parse_args):
         "image_to_scan": "image",
         "dast_file_path": "dast_file_path",
         "context": "false",
-        "repo_name" : None,
         "token_engine_code": None
     }
 

--- a/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/azuredevopscore/test_azure_devops.py
+++ b/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/azuredevopscore/test_azure_devops.py
@@ -1,7 +1,10 @@
+import os
 import unittest
 from unittest.mock import MagicMock
 from unittest import mock
+
 from devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.azure.azure_devops import AzureDevops
+from tools.devsecops_engine_tools.engine_utilities.azuredevops.models import AzurePredefinedVariables
 
 class TestAzureDevops(unittest.TestCase):
 
@@ -116,3 +119,78 @@ class TestAzureDevops(unittest.TestCase):
 
         result = azure_devops.get_variable("access_token")
         assert result == "System_AccessToken"
+
+class TestEnvVariables(unittest.TestCase):
+    @mock.patch('os.environ.get')
+    def test_get_value_variable_exists(self, mock_env_get):
+        # Arrange
+        mock_env_get.return_value = "test_value"
+        
+        # Act
+        result = AzurePredefinedVariables.EnvVariables.get_value("TEST_VARIABLE")
+        
+        # Assert
+        self.assertEqual(result, "test_value")
+        mock_env_get.assert_called_once_with("TEST_VARIABLE")
+
+    @mock.patch('os.environ.get')
+    def test_get_value_variable_not_exists(self, mock_env_get):
+        # Arrange
+        mock_env_get.return_value = None
+        
+        # Act & Assert
+        with self.assertRaises(ValueError) as context:
+            AzurePredefinedVariables.EnvVariables.get_value("TEST_VARIABLE")
+        self.assertEqual(str(context.exception), "La variable de entorno TEST_VARIABLE no está definida")
+        mock_env_get.assert_called_once_with("TEST_VARIABLE")
+
+    @mock.patch('os.environ.get')
+    def test_get_value_custom_repository_name_none(self, mock_env_get):
+        # Arrange
+        mock_env_get.return_value = None
+        
+        # Act
+        result = AzurePredefinedVariables.EnvVariables.get_value("CUSTOM_REPOSITORY_NAME")
+        
+        # Assert
+        self.assertIsNone(result)
+        mock_env_get.assert_called_once_with("CUSTOM_REPOSITORY_NAME")
+
+    @mock.patch('os.environ.get')
+    def test_get_value_custom_pipeline_name_none(self, mock_env_get):
+        # Arrange
+        mock_env_get.return_value = None
+        
+        # Act
+        result = AzurePredefinedVariables.EnvVariables.get_value("CUSTOM_PIPELINE_NAME")
+        
+        # Assert
+        self.assertIsNone(result)
+        mock_env_get.assert_called_once_with("CUSTOM_PIPELINE_NAME")
+
+    @mock.patch('os.environ.get')
+    def test_get_value_custom_repository_name_exists(self, mock_env_get):
+        # Arrange
+        mock_env_get.return_value = "repo_name"
+        
+        # Act
+        result = AzurePredefinedVariables.EnvVariables.get_value("CUSTOM_REPOSITORY_NAME")
+        
+        # Assert
+        self.assertEqual(result, "repo_name")
+        mock_env_get.assert_called_once_with("CUSTOM_REPOSITORY_NAME")
+
+    @mock.patch('os.environ.get')
+    def test_get_value_custom_pipeline_name_exists(self, mock_env_get):
+        # Arrange
+        mock_env_get.return_value = "pipeline_name"
+        
+        # Act
+        result = AzurePredefinedVariables.EnvVariables.get_value("CUSTOM_PIPELINE_NAME")
+        
+        # Assert
+        self.assertEqual(result, "pipeline_name")
+        mock_env_get.assert_called_once_with("CUSTOM_PIPELINE_NAME")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/github/test_github_actions.py
+++ b/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/github/test_github_actions.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import MagicMock
 from unittest import mock
 from devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.github.github_actions import GithubActions
-
+from tools.devsecops_engine_tools.engine_utilities.github.models import GithubPredefinedVariables
 
 class TestGithubActions(unittest.TestCase):
 
@@ -121,3 +121,79 @@ class TestGithubActions(unittest.TestCase):
 
         result = github_actions.get_variable("access_token")
         assert result == "github_access_token"
+
+
+class TestEnvVariables(unittest.TestCase):
+    @mock.patch('os.environ.get')
+    def test_get_value_variable_exists(self, mock_env_get):
+        # Arrange
+        mock_env_get.return_value = "test_value"
+        
+        # Act
+        result = GithubPredefinedVariables.EnvVariables.get_value("TEST_VARIABLE")
+        
+        # Assert
+        self.assertEqual(result, "test_value")
+        mock_env_get.assert_called_once_with("TEST_VARIABLE")
+
+    @mock.patch('os.environ.get')
+    def test_get_value_variable_not_exists(self, mock_env_get):
+        # Arrange
+        mock_env_get.return_value = None
+        
+        # Act & Assert
+        with self.assertRaises(ValueError) as context:
+            GithubPredefinedVariables.EnvVariables.get_value("TEST_VARIABLE")
+        self.assertEqual(str(context.exception), "La variable de entorno TEST_VARIABLE no está definida")
+        mock_env_get.assert_called_once_with("TEST_VARIABLE")
+
+    @mock.patch('os.environ.get')
+    def test_get_value_custom_repository_name_none(self, mock_env_get):
+        # Arrange
+        mock_env_get.return_value = None
+        
+        # Act
+        result = GithubPredefinedVariables.EnvVariables.get_value("CUSTOM_REPOSITORY_NAME")
+        
+        # Assert
+        self.assertIsNone(result)
+        mock_env_get.assert_called_once_with("CUSTOM_REPOSITORY_NAME")
+
+    @mock.patch('os.environ.get')
+    def test_get_value_custom_pipeline_name_none(self, mock_env_get):
+        # Arrange
+        mock_env_get.return_value = None
+        
+        # Act
+        result = GithubPredefinedVariables.EnvVariables.get_value("CUSTOM_PIPELINE_NAME")
+        
+        # Assert
+        self.assertIsNone(result)
+        mock_env_get.assert_called_once_with("CUSTOM_PIPELINE_NAME")
+
+    @mock.patch('os.environ.get')
+    def test_get_value_custom_repository_name_exists(self, mock_env_get):
+        # Arrange
+        mock_env_get.return_value = "repo_name"
+        
+        # Act
+        result = GithubPredefinedVariables.EnvVariables.get_value("CUSTOM_REPOSITORY_NAME")
+        
+        # Assert
+        self.assertEqual(result, "repo_name")
+        mock_env_get.assert_called_once_with("CUSTOM_REPOSITORY_NAME")
+
+    @mock.patch('os.environ.get')
+    def test_get_value_custom_pipeline_name_exists(self, mock_env_get):
+        # Arrange
+        mock_env_get.return_value = "pipeline_name"
+        
+        # Act
+        result = GithubPredefinedVariables.EnvVariables.get_value("CUSTOM_PIPELINE_NAME")
+        
+        # Assert
+        self.assertEqual(result, "pipeline_name")
+        mock_env_get.assert_called_once_with("CUSTOM_PIPELINE_NAME")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/devsecops_engine_tools/engine_sast/engine_code/src/domain/usecases/code_scan.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_code/src/domain/usecases/code_scan.py
@@ -194,7 +194,7 @@ class CodeScan:
                 dict_args["folder_path"],
                 pull_request_files,
                 self.devops_platform_gateway.get_variable("path_directory"),
-                dict_args.get("repo_name", False) if dict_args.get("repo_name", False) else self.devops_platform_gateway.get_variable("repository"),
+                self.devops_platform_gateway.get_variable("repository"),
                 config_tool,
             )
 

--- a/tools/devsecops_engine_tools/engine_utilities/azuredevops/models/AzurePredefinedVariables.py
+++ b/tools/devsecops_engine_tools/engine_utilities/azuredevops/models/AzurePredefinedVariables.py
@@ -10,7 +10,11 @@ class EnvVariables:
     @staticmethod
     def get_value(env_name):
         env_var = os.environ.get(env_name)
-        if env_var is None:
+        is_env_var_none = env_var is None
+        if (env_name == "CUSTOM_REPOSITORY_NAME" or env_name == "CUSTOM_PIPELINE_NAME") and is_env_var_none:
+            return None
+            
+        if is_env_var_none:
             raise ValueError(f"La variable de entorno {env_name} no está definida")
         return env_var
 

--- a/tools/devsecops_engine_tools/engine_utilities/azuredevops/models/AzurePredefinedVariables.py
+++ b/tools/devsecops_engine_tools/engine_utilities/azuredevops/models/AzurePredefinedVariables.py
@@ -69,5 +69,7 @@ class VMVariables(BaseEnum):
     Vm_Product_Name = "Vm.Product.Name"
     Vm_Product_Description = "Vm.Product.Description"
 
-class ApplicationVariables(BaseEnum):
-    Application_Build_Task = "BUILDTASK"
+class CustomVariables(BaseEnum):
+    Build_Task = "BUILDTASK"
+    Pipeline_Name = "Custom.Pipeline.Name"
+    Repository_Name  = "Custom.Repository.Name"

--- a/tools/devsecops_engine_tools/engine_utilities/azuredevops/models/AzurePredefinedVariables.py
+++ b/tools/devsecops_engine_tools/engine_utilities/azuredevops/models/AzurePredefinedVariables.py
@@ -11,7 +11,7 @@ class EnvVariables:
     def get_value(env_name):
         env_var = os.environ.get(env_name)
         is_env_var_none = env_var is None
-        if (env_name == "CUSTOM_REPOSITORY_NAME" or env_name == "CUSTOM_PIPELINE_NAME") and is_env_var_none:
+        if env_name in ("CUSTOM_REPOSITORY_NAME", "CUSTOM_PIPELINE_NAME") and is_env_var_none:
             return None
             
         if is_env_var_none:

--- a/tools/devsecops_engine_tools/engine_utilities/github/models/GithubPredefinedVariables.py
+++ b/tools/devsecops_engine_tools/engine_utilities/github/models/GithubPredefinedVariables.py
@@ -7,7 +7,11 @@ class EnvVariables:
     @staticmethod
     def get_value(env_name):
         env_var = os.environ.get(env_name)
-        if env_var is None:
+        is_env_var_none = env_var is None
+        if (env_name == "CUSTOM_REPOSITORY_NAME" or env_name == "CUSTOM_PIPELINE_NAME") and is_env_var_none:
+            return None
+            
+        if is_env_var_none:
             raise ValueError(f"La variable de entorno {env_name} no está definida")
         return env_var
 

--- a/tools/devsecops_engine_tools/engine_utilities/github/models/GithubPredefinedVariables.py
+++ b/tools/devsecops_engine_tools/engine_utilities/github/models/GithubPredefinedVariables.py
@@ -8,7 +8,7 @@ class EnvVariables:
     def get_value(env_name):
         env_var = os.environ.get(env_name)
         is_env_var_none = env_var is None
-        if (env_name == "CUSTOM_REPOSITORY_NAME" or env_name == "CUSTOM_PIPELINE_NAME") and is_env_var_none:
+        if env_name in ("CUSTOM_REPOSITORY_NAME", "CUSTOM_PIPELINE_NAME") and is_env_var_none:
             return None
             
         if is_env_var_none:

--- a/tools/devsecops_engine_tools/engine_utilities/github/models/GithubPredefinedVariables.py
+++ b/tools/devsecops_engine_tools/engine_utilities/github/models/GithubPredefinedVariables.py
@@ -61,5 +61,7 @@ class VMVariables(BaseEnum):
     Vm_Product_Name = "Vm.Product.Name"
     Vm_Product_Description = "Vm.Product.Description"
 
-class ApplicationVariables(BaseEnum):
-    Application_Build_Task = "BUILDTASK"
+class CustomVariables(BaseEnum):
+    Build_Task = "BUILDTASK"
+    Pipeline_Name = "Custom.Pipeline.Name"
+    Repository_Name  = "Custom.Repository.Name"


### PR DESCRIPTION
## Description

Due to sometimes is neccessary to use a different repository name thande build.repository name and build.pipeline name, a custom names funcionality was added. Now the use a custom values is allowed for any tool

### Feat


## Checklist:

- [ ] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
