### PR TITLE
feat(engine_secret): Exclusion by detectors is added in Trufflehog

### DIFF
--- a/docs/Docusaurus/docs/life_cycle/remote_config_structure.md
+++ b/docs/Docusaurus/docs/life_cycle/remote_config_structure.md
@@ -1446,6 +1446,7 @@ Secret scanning is a process that detects vulnerabilities in the application's s
     "trufflehog": {
         "VERSION": "3.88.31",
         "EXCLUDE_PATH": [".git", "_venv"],
+        "EXCLUDE_DETECTORS": ["aws", "userflow"], // Value can be []
         "NUMBER_THREADS": 4,
         "ENABLE_CUSTOM_RULES" : false,
         "EXTERNAL_DIR_OWNER": "ExternalOrg",

--- a/example_remote_config_local/engine_sast/engine_secret/ConfigTool.json
+++ b/example_remote_config_local/engine_sast/engine_secret/ConfigTool.json
@@ -16,6 +16,7 @@
     "trufflehog": {
         "VERSION": "3.88.31",
         "EXCLUDE_PATH": [".git", "_venv"],
+        "EXCLUDE_DETECTORS": ["aws", "userflow"],
         "NUMBER_THREADS": 4,
         "ENABLE_CUSTOM_RULES" : false,
         "EXTERNAL_DIR_OWNER": "ExternalOrg",

--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/src/infrastructure/driven_adapters/trufflehog/trufflehog_run.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/src/infrastructure/driven_adapters/trufflehog/trufflehog_run.py
@@ -76,6 +76,9 @@ class TrufflehogRun(ToolGateway):
         enable_custom_rules = config_tool[tool]["ENABLE_CUSTOM_RULES"]
         if enable_custom_rules:
             Utils().configurate_external_checks(tool, config_tool, secret_tool, secret_external_checks, path)
+        exclude_detectors = config_tool[tool]["EXCLUDE_DETECTORS"]
+        if exclude_detectors:
+            exclude_detectors = ",".join(exclude_detectors)
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=config_tool[tool]["NUMBER_THREADS"]) as executor:
             results = executor.map(
@@ -87,7 +90,8 @@ class TrufflehogRun(ToolGateway):
                 [repository_name] * len(include_paths),
                 [enable_custom_rules] * len(include_paths),
                 [agent_os] * len(include_paths),
-                [folder_path] * len(include_paths)
+                [folder_path] * len(include_paths),
+                [exclude_detectors] * len(include_paths)
             )
         findings, file_findings = self.create_file(self.decode_output(results), path, config_tool, tool)
         return  findings, file_findings
@@ -124,7 +128,8 @@ class TrufflehogRun(ToolGateway):
         repository_name,
         enable_custom_rules,
         agent_os,
-        folder_path
+        folder_path,
+        exclude_detectors
     ):
         path_folder = folder_path if folder_path is not None else f"{path}/{repository_name}"
         command = f"{trufflehog_command} filesystem {path_folder} --include-paths {include_path} --exclude-paths {exclude_path} --no-verification --no-update --json"
@@ -132,6 +137,9 @@ class TrufflehogRun(ToolGateway):
             command = command.replace("--no-verification --no-update --json", f"--config {path}//rules//trufflehog//custom-rules.yaml --no-verification --no-update --json" if "Windows" in agent_os else
                                       f"--config {path}/rules/trufflehog/custom-rules.yaml --no-verification --no-update --json" if "Linux" or "Darwin" in agent_os else
                                       "--no-verification --no-update --json")
+            
+        if exclude_detectors:
+            command = f"{command} --exclude-detectors {exclude_detectors}"
             
         result = subprocess.run(command, capture_output=True, shell=True, text=True, encoding='utf-8')
         return result.stdout.strip()

--- a/tools/devsecops_engine_tools/engine_sast/engine_secret/test/infrastructure/driven_adapters/trufflehog/test_trufflehog_run.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_secret/test/infrastructure/driven_adapters/trufflehog/test_trufflehog_run.py
@@ -116,6 +116,7 @@ class TestTrufflehogRun(unittest.TestCase):
                 "trufflehog": {
                     "VERSION": "1.2.3",
                     "EXCLUDE_PATH": [".git", "node_modules", "target", "build", "build.gradle", "twistcli-scan", ".svg", ".drawio"],
+                    "EXCLUDE_DETECTORS": ["userflow"],
                     "NUMBER_THREADS": 4,
                     "ENABLE_CUSTOM_RULES" : "True",
                     "EXTERNAL_DIR_OWNER": "External_Github",
@@ -175,7 +176,7 @@ class TestTrufflehogRun(unittest.TestCase):
         enable_custom_rules = False
         trufflehog_run = TrufflehogRun()
 
-        result = trufflehog_run.run_trufflehog('trufflehog', '/usr/local', '/usr/temp/excludedPath.txt', '/usr/temp/includePath0.txt', 'NU00000_Repo_Test', enable_custom_rules, "trufflehog", "/")
+        result = trufflehog_run.run_trufflehog('trufflehog', '/usr/local', '/usr/temp/excludedPath.txt', '/usr/temp/includePath0.txt', 'NU00000_Repo_Test', enable_custom_rules, "trufflehog", "/", "aws,userflow")
 
         expected_result = '{"SourceMetadata":{"Data":{"Filesystem":{"file":"/usr/bin/local/file1.txt","line":1}}},"SourceID":1,"SourceType":15,"SourceName":"trufflehog - filesystem","DetectorType":17,"DetectorName":"URI","DecoderName":"BASE64","Verified":false,"Raw":"https://admin:admin@the-internet.herokuapp.com","RawV2":"https://admin:admin@the-internet.herokuapp.com/basic_auth","Redacted":"https://admin:********@the-internet.herokuapp.com","ExtraData":null,"StructuredData":null}'
         self.assertEqual(result, expected_result)
@@ -186,7 +187,7 @@ class TestTrufflehogRun(unittest.TestCase):
         enable_custom_rules = True
         trufflehog_run = TrufflehogRun()
 
-        result = trufflehog_run.run_trufflehog('trufflehog', '/usr/local', '/usr/temp/excludedPath.txt', '/usr/temp/includePath0.txt', 'NU00000_Repo_Test', enable_custom_rules, "trufflehog", "/")
+        result = trufflehog_run.run_trufflehog('trufflehog', '/usr/local', '/usr/temp/excludedPath.txt', '/usr/temp/includePath0.txt', 'NU00000_Repo_Test', enable_custom_rules, "trufflehog", "/", "aws,userflow")
 
         expected_result = '{"SourceMetadata":{"Data":{"Filesystem":{"file":"/usr/bin/local/file1.txt","line":1}}},"SourceID":1,"SourceType":15,"SourceName":"trufflehog - filesystem","DetectorType":17,"DetectorName":"URI","DecoderName":"BASE64","Verified":false,"Raw":"https://admin:admin@the-internet.herokuapp.com","RawV2":"https://admin:admin@the-internet.herokuapp.com/basic_auth","Redacted":"https://admin:********@the-internet.herokuapp.com","ExtraData":null,"StructuredData":null}'
         self.assertEqual(result, expected_result)


### PR DESCRIPTION
## Description

Added configuration to configTool.json to exclude trufflehog detectors, this reduces the number of false positives

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
