### PR TITLE
feat(cdxgen): add recurse and exclude types to sbom gen

### DIFF
--- a/docs/Docusaurus/docs/life_cycle/remote_config_structure.md
+++ b/docs/Docusaurus/docs/life_cycle/remote_config_structure.md
@@ -147,7 +147,10 @@ Configuration of the driven adapters in the main layer and management of on/off 
         "CDXGEN": {
             "CDXGEN_VERSION": "11.6.0",
             "OUTPUT_FORMAT": "cyclonedx-json",
-            "SLIM_BINARY": false
+            "SLIM_BINARY": false,
+            "EXCLUDE_TYPES": "",
+            "RECURSE": true,
+            "DEBUG_PIPELINES": ["pipeline_name1", "pipeline_name2"]
         }
     },
     "ENGINE_IAC": {

--- a/example_remote_config_local/engine_core/ConfigTool.json
+++ b/example_remote_config_local/engine_core/ConfigTool.json
@@ -97,7 +97,10 @@
         "CDXGEN": {
             "CDXGEN_VERSION": "11.6.0",
             "OUTPUT_FORMAT": "cyclonedx-json",
-            "SLIM_BINARY": false
+            "SLIM_BINARY": false,
+            "EXCLUDE_TYPES": "",
+            "RECURSE": true,
+            "DEBUG_PIPELINES": ["pipeline_name1", "pipeline_name2"]
         }
     },
     "ENGINE_IAC": {

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/cdxgen/cdxgen.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/cdxgen/cdxgen.py
@@ -89,7 +89,6 @@ class CdxGen(SbomManagerGateway):
         try:
             result = subprocess.run(
                 command,
-                check=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True
@@ -101,8 +100,12 @@ class CdxGen(SbomManagerGateway):
                 if result.stderr:
                     logger.info(f"CDXGEN stderr: {result.stderr}")
             
-            print(f"SBOM generated and saved to: {result_file}")
-            return result_file
+            if result.returncode == 0:
+                print(f"SBOM generated and saved to: {result_file}")
+                return result_file
+            else:
+                raise Exception(f"CDXGEN command failed with return code: {result.returncode}")
+
         except Exception as e:
             logger.error(f"Error running cdxgen: {e}")
 

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/cdxgen/cdxgen.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/cdxgen/cdxgen.py
@@ -26,6 +26,9 @@ class CdxGen(SbomManagerGateway):
         try:
             cdxgen_version = config["CDXGEN"]["CDXGEN_VERSION"]
             slim = "-slim" if config["CDXGEN"]["SLIM_BINARY"] else ""
+            exclude_types = config["CDXGEN"].get("EXCLUDE_TYPES", "")
+            recurse = config["CDXGEN"].get("RECURSE", True)
+
             os_platform = platform.system()
             base_url = (
                 f"https://github.com/CycloneDX/cdxgen/releases/download/v{cdxgen_version}/"
@@ -51,20 +54,30 @@ class CdxGen(SbomManagerGateway):
                 logger.warning(f"{os_platform} is not supported.")
                 return None
 
-            result_sbom = self._run_cdxgen(command_prefix, artifact, service_name)
+            result_sbom = self._run_cdxgen(command_prefix, artifact, service_name, exclude_types, recurse)
             return get_list_component(result_sbom, config["CDXGEN"]["OUTPUT_FORMAT"])
         except Exception as e:
             logger.error(f"Error generating SBOM: {e}")
             return None
 
-    def _run_cdxgen(self, command_prefix, artifact, service_name):
+    def _run_cdxgen(self, command_prefix, artifact, service_name, exclude_types, recurse):
         result_file = f"{service_name}_SBOM.json"
         command = [
             command_prefix,
             artifact,
             "-o",
-            result_file,
+            result_file
         ]
+
+        if exclude_types:
+            command.extend(
+                ["--exclude-type", exclude_types]
+            )
+        
+        if not recurse:
+            command.append(
+                "--no-recurse"
+            )
 
         try:
             subprocess.run(

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/cdxgen/cdxgen.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/cdxgen/cdxgen.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 import requests
 import subprocess
 import platform
+import os
 
 from devsecops_engine_tools.engine_core.src.domain.model.gateway.sbom_manager import (
     SbomManagerGateway,
@@ -28,6 +29,12 @@ class CdxGen(SbomManagerGateway):
             slim = "-slim" if config["CDXGEN"]["SLIM_BINARY"] else ""
             exclude_types = config["CDXGEN"].get("EXCLUDE_TYPES", "")
             recurse = config["CDXGEN"].get("RECURSE", True)
+            debug_pipelines = config["CDXGEN"].get("DEBUG_PIPELINES", [])
+            
+            enable_debug = service_name in debug_pipelines if debug_pipelines else False
+            if enable_debug:
+                logger.info(f"Enabling debug mode for pipeline: {service_name}")
+                os.environ["CDXGEN_DEBUG_MODE"] = "debug"
 
             os_platform = platform.system()
             base_url = (
@@ -54,13 +61,13 @@ class CdxGen(SbomManagerGateway):
                 logger.warning(f"{os_platform} is not supported.")
                 return None
 
-            result_sbom = self._run_cdxgen(command_prefix, artifact, service_name, exclude_types, recurse)
+            result_sbom = self._run_cdxgen(command_prefix, artifact, service_name, exclude_types, recurse, enable_debug)
             return get_list_component(result_sbom, config["CDXGEN"]["OUTPUT_FORMAT"])
         except Exception as e:
             logger.error(f"Error generating SBOM: {e}")
             return None
 
-    def _run_cdxgen(self, command_prefix, artifact, service_name, exclude_types, recurse):
+    def _run_cdxgen(self, command_prefix, artifact, service_name, exclude_types, recurse, enable_debug=False):
         result_file = f"{service_name}_SBOM.json"
         command = [
             command_prefix,
@@ -80,13 +87,20 @@ class CdxGen(SbomManagerGateway):
             )
 
         try:
-            subprocess.run(
+            result = subprocess.run(
                 command,
                 check=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                text=True,
+                text=True
             )
+            
+            if enable_debug:
+                if result.stdout:
+                    logger.info(f"CDXGEN stdout: {result.stdout}")
+                if result.stderr:
+                    logger.info(f"CDXGEN stderr: {result.stderr}")
+            
             print(f"SBOM generated and saved to: {result_file}")
             return result_file
         except Exception as e:

--- a/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/cdxgen/test_cdxgen.py
+++ b/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/cdxgen/test_cdxgen.py
@@ -18,7 +18,8 @@ class TestCdxGen(unittest.TestCase):
                 "SLIM_BINARY": False,
                 "OUTPUT_FORMAT": "json",
                 "EXCLUDE_TYPES": "",
-                "RECURSE": True
+                "RECURSE": True,
+                "DEBUG_PIPELINES": []
             }
         }
         
@@ -28,7 +29,8 @@ class TestCdxGen(unittest.TestCase):
                 "SLIM_BINARY": True,
                 "OUTPUT_FORMAT": "json",
                 "EXCLUDE_TYPES": "",
-                "RECURSE": True
+                "RECURSE": True,
+                "DEBUG_PIPELINES": []
             }
         }
         
@@ -57,7 +59,7 @@ class TestCdxGen(unittest.TestCase):
             "https://github.com/CycloneDX/cdxgen/releases/download/v10.2.0/cdxgen-linux-amd64",
             "cdxgen"
         )
-        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, "", True)
+        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, "", True, False)
         mock_get_list_component.assert_called_once_with('test_service_SBOM.json', 'json')
 
     @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.get_list_component')
@@ -154,13 +156,15 @@ class TestCdxGen(unittest.TestCase):
         command_prefix = "/usr/local/bin/cdxgen"
         exclude_types = ""
         recurse = True
-        mock_subprocess.return_value = Mock(returncode=0)
+        enable_debug = False
+        mock_result = Mock(returncode=0, stdout="", stderr="")
+        mock_subprocess.return_value = mock_result
         expected_result_file = f"{self.service_name}_SBOM.json"
         expected_command = [command_prefix, self.artifact, "-o", expected_result_file]
         
         # Act
         with patch('builtins.print') as mock_print:
-            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, recurse)
+            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, recurse, enable_debug)
         
         # Assert
         self.assertEqual(result, expected_result_file)
@@ -180,15 +184,99 @@ class TestCdxGen(unittest.TestCase):
         command_prefix = "/usr/local/bin/cdxgen"
         exclude_types = ""
         recurse = True
+        enable_debug = False
         error_message = "Command execution failed"
         mock_subprocess.side_effect = Exception(error_message)
         
         # Act
-        result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, recurse)
+        result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, recurse, enable_debug)
         
         # Assert
         self.assertIsNone(result)
         mock_logger.error.assert_called_once_with(f"Error running cdxgen: {error_message}")
+
+    @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.subprocess.run')
+    @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.logger')
+    def test_run_cdxgen_debug_mode_enabled(self, mock_logger, mock_subprocess):
+        # Arrange
+        command_prefix = "/usr/local/bin/cdxgen"
+        exclude_types = ""
+        recurse = True
+        enable_debug = True
+        mock_result = Mock(returncode=0, stdout="Debug stdout output", stderr="Debug stderr output")
+        mock_subprocess.return_value = mock_result
+        expected_result_file = f"{self.service_name}_SBOM.json"
+        
+        # Act
+        with patch('builtins.print') as mock_print:
+            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, recurse, enable_debug)
+        
+        # Assert
+        self.assertEqual(result, expected_result_file)
+        # Verify that debug info is logged (based on actual implementation)
+        mock_logger.info.assert_any_call("CDXGEN stdout: Debug stdout output")
+        mock_logger.info.assert_any_call("CDXGEN stderr: Debug stderr output")
+        
+        # Verify the final print call
+        mock_print.assert_called_with(f"SBOM generated and saved to: {expected_result_file}")
+
+    @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.get_list_component')
+    @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.platform.system')
+    @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.logger')
+    def test_get_components_debug_mode_service_in_list(self, mock_logger, mock_platform, mock_get_list_component):
+        # Arrange
+        mock_platform.return_value = "Linux"
+        mock_get_list_component.return_value = self.mock_components
+        
+        # Config with DEBUG_PIPELINES containing our service
+        debug_config = {
+            "CDXGEN": {
+                "CDXGEN_VERSION": "10.2.0",
+                "SLIM_BINARY": False,
+                "OUTPUT_FORMAT": "json",
+                "EXCLUDE_TYPES": "",
+                "RECURSE": True,
+                "DEBUG_PIPELINES": ["test_service", "another_service"]
+            }
+        }
+        
+        with patch.object(self.cdxgen, '_install_tool_unix', return_value='/usr/local/bin/cdxgen') as mock_install:
+            with patch.object(self.cdxgen, '_run_cdxgen', return_value='test_service_SBOM.json') as mock_run:
+                # Act
+                result = self.cdxgen.get_components(self.artifact, debug_config, self.service_name)
+        
+        # Assert
+        self.assertEqual(result, self.mock_components)
+        mock_logger.info.assert_called_with(f"Enabling debug mode for pipeline: {self.service_name}")
+        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, "", True, True)
+
+    @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.get_list_component')
+    @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.platform.system')
+    def test_get_components_debug_mode_service_not_in_list(self, mock_platform, mock_get_list_component):
+        # Arrange
+        mock_platform.return_value = "Linux"
+        mock_get_list_component.return_value = self.mock_components
+        
+        # Config with DEBUG_PIPELINES not containing our service
+        debug_config = {
+            "CDXGEN": {
+                "CDXGEN_VERSION": "10.2.0",
+                "SLIM_BINARY": False,
+                "OUTPUT_FORMAT": "json",
+                "EXCLUDE_TYPES": "",
+                "RECURSE": True,
+                "DEBUG_PIPELINES": ["other_service", "another_service"]
+            }
+        }
+        
+        with patch.object(self.cdxgen, '_install_tool_unix', return_value='/usr/local/bin/cdxgen') as mock_install:
+            with patch.object(self.cdxgen, '_run_cdxgen', return_value='test_service_SBOM.json') as mock_run:
+                # Act
+                result = self.cdxgen.get_components(self.artifact, debug_config, self.service_name)
+        
+        # Assert
+        self.assertEqual(result, self.mock_components)
+        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, "", True, False)
 
     @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.subprocess.run')
     def test_install_tool_unix_already_installed(self, mock_subprocess):

--- a/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/cdxgen/test_cdxgen.py
+++ b/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/cdxgen/test_cdxgen.py
@@ -16,7 +16,9 @@ class TestCdxGen(unittest.TestCase):
             "CDXGEN": {
                 "CDXGEN_VERSION": "10.2.0",
                 "SLIM_BINARY": False,
-                "OUTPUT_FORMAT": "json"
+                "OUTPUT_FORMAT": "json",
+                "EXCLUDE_TYPES": "",
+                "RECURSE": True
             }
         }
         
@@ -24,7 +26,9 @@ class TestCdxGen(unittest.TestCase):
             "CDXGEN": {
                 "CDXGEN_VERSION": "10.2.0",
                 "SLIM_BINARY": True,
-                "OUTPUT_FORMAT": "json"
+                "OUTPUT_FORMAT": "json",
+                "EXCLUDE_TYPES": "",
+                "RECURSE": True
             }
         }
         
@@ -53,7 +57,7 @@ class TestCdxGen(unittest.TestCase):
             "https://github.com/CycloneDX/cdxgen/releases/download/v10.2.0/cdxgen-linux-amd64",
             "cdxgen"
         )
-        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name)
+        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, "", True)
         mock_get_list_component.assert_called_once_with('test_service_SBOM.json', 'json')
 
     @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.get_list_component')
@@ -148,13 +152,15 @@ class TestCdxGen(unittest.TestCase):
     def test_run_cdxgen_success(self, mock_subprocess):
         # Arrange
         command_prefix = "/usr/local/bin/cdxgen"
+        exclude_types = ""
+        recurse = True
         mock_subprocess.return_value = Mock(returncode=0)
         expected_result_file = f"{self.service_name}_SBOM.json"
         expected_command = [command_prefix, self.artifact, "-o", expected_result_file]
         
         # Act
         with patch('builtins.print') as mock_print:
-            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name)
+            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, recurse)
         
         # Assert
         self.assertEqual(result, expected_result_file)
@@ -172,11 +178,13 @@ class TestCdxGen(unittest.TestCase):
     def test_run_cdxgen_failure(self, mock_subprocess, mock_logger):
         # Arrange
         command_prefix = "/usr/local/bin/cdxgen"
+        exclude_types = ""
+        recurse = True
         error_message = "Command execution failed"
         mock_subprocess.side_effect = Exception(error_message)
         
         # Act
-        result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name)
+        result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, recurse)
         
         # Assert
         self.assertIsNone(result)

--- a/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/cdxgen/test_cdxgen.py
+++ b/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/cdxgen/test_cdxgen.py
@@ -170,7 +170,6 @@ class TestCdxGen(unittest.TestCase):
         self.assertEqual(result, expected_result_file)
         mock_subprocess.assert_called_once_with(
             expected_command,
-            check=True,
             stdout=unittest.mock.ANY,
             stderr=unittest.mock.ANY,
             text=True


### PR DESCRIPTION
## Description

add recurse and exclude types to sbom generation with cdxgen

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
