### PR TITLE
feat: add exclude types and paths to cdxgen configs

### DIFF
--- a/docs/Docusaurus/docs/life_cycle/remote_config_structure.md
+++ b/docs/Docusaurus/docs/life_cycle/remote_config_structure.md
@@ -148,7 +148,8 @@ Configuration of the driven adapters in the main layer and management of on/off 
             "CDXGEN_VERSION": "11.6.0",
             "OUTPUT_FORMAT": "cyclonedx-json",
             "SLIM_BINARY": false,
-            "EXCLUDE_TYPES": "",
+            "EXCLUDE_TYPES": ["jar"],
+            "EXCLUDE_PATHS": ["**/test/**"],
             "RECURSE": true,
             "DEBUG_PIPELINES": ["pipeline_name1", "pipeline_name2"]
         }

--- a/example_remote_config_local/engine_core/ConfigTool.json
+++ b/example_remote_config_local/engine_core/ConfigTool.json
@@ -98,7 +98,8 @@
             "CDXGEN_VERSION": "11.6.0",
             "OUTPUT_FORMAT": "cyclonedx-json",
             "SLIM_BINARY": false,
-            "EXCLUDE_TYPES": "",
+            "EXCLUDE_TYPES": ["jar"],
+            "EXCLUDE_PATHS": ["**/test/**"],
             "RECURSE": true,
             "DEBUG_PIPELINES": ["pipeline_name1", "pipeline_name2"]
         }

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/cdxgen/cdxgen.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/cdxgen/cdxgen.py
@@ -27,7 +27,8 @@ class CdxGen(SbomManagerGateway):
         try:
             cdxgen_version = config["CDXGEN"]["CDXGEN_VERSION"]
             slim = "-slim" if config["CDXGEN"]["SLIM_BINARY"] else ""
-            exclude_types = config["CDXGEN"].get("EXCLUDE_TYPES", "")
+            exclude_types = config["CDXGEN"].get("EXCLUDE_TYPES", [])
+            exclude_paths = config["CDXGEN"].get("EXCLUDE_PATHS", [])
             recurse = config["CDXGEN"].get("RECURSE", True)
             debug_pipelines = config["CDXGEN"].get("DEBUG_PIPELINES", [])
             
@@ -61,13 +62,13 @@ class CdxGen(SbomManagerGateway):
                 logger.warning(f"{os_platform} is not supported.")
                 return None
 
-            result_sbom = self._run_cdxgen(command_prefix, artifact, service_name, exclude_types, recurse, enable_debug)
+            result_sbom = self._run_cdxgen(command_prefix, artifact, service_name, exclude_types, exclude_paths, recurse, enable_debug)
             return get_list_component(result_sbom, config["CDXGEN"]["OUTPUT_FORMAT"])
         except Exception as e:
             logger.error(f"Error generating SBOM: {e}")
             return None
 
-    def _run_cdxgen(self, command_prefix, artifact, service_name, exclude_types, recurse, enable_debug=False):
+    def _run_cdxgen(self, command_prefix, artifact, service_name, exclude_types, exclude_paths, recurse, enable_debug=False):
         result_file = f"{service_name}_SBOM.json"
         command = [
             command_prefix,
@@ -77,9 +78,16 @@ class CdxGen(SbomManagerGateway):
         ]
 
         if exclude_types:
-            command.extend(
-                ["--exclude-type", exclude_types]
-            )
+            for ex in exclude_types:
+                command.extend(
+                    ["--exclude-type", ex]
+                )
+
+        if exclude_paths:
+            for ex in exclude_paths:
+                command.extend(
+                    ["--exclude", ex]
+                )
         
         if not recurse:
             command.append(

--- a/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/cdxgen/test_cdxgen.py
+++ b/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/cdxgen/test_cdxgen.py
@@ -17,7 +17,8 @@ class TestCdxGen(unittest.TestCase):
                 "CDXGEN_VERSION": "10.2.0",
                 "SLIM_BINARY": False,
                 "OUTPUT_FORMAT": "json",
-                "EXCLUDE_TYPES": "",
+                "EXCLUDE_TYPES": [],
+                "EXCLUDE_PATHS": [],
                 "RECURSE": True,
                 "DEBUG_PIPELINES": []
             }
@@ -28,7 +29,8 @@ class TestCdxGen(unittest.TestCase):
                 "CDXGEN_VERSION": "10.2.0",
                 "SLIM_BINARY": True,
                 "OUTPUT_FORMAT": "json",
-                "EXCLUDE_TYPES": "",
+                "EXCLUDE_TYPES": [],
+                "EXCLUDE_PATHS": [],
                 "RECURSE": True,
                 "DEBUG_PIPELINES": []
             }
@@ -59,7 +61,7 @@ class TestCdxGen(unittest.TestCase):
             "https://github.com/CycloneDX/cdxgen/releases/download/v10.2.0/cdxgen-linux-amd64",
             "cdxgen"
         )
-        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, "", True, False)
+        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, [], [], True, False)
         mock_get_list_component.assert_called_once_with('test_service_SBOM.json', 'json')
 
     @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.get_list_component')
@@ -154,7 +156,8 @@ class TestCdxGen(unittest.TestCase):
     def test_run_cdxgen_success(self, mock_subprocess):
         # Arrange
         command_prefix = "/usr/local/bin/cdxgen"
-        exclude_types = ""
+        exclude_types = []
+        exclude_paths = []
         recurse = True
         enable_debug = False
         mock_result = Mock(returncode=0, stdout="", stderr="")
@@ -164,7 +167,7 @@ class TestCdxGen(unittest.TestCase):
         
         # Act
         with patch('builtins.print') as mock_print:
-            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, recurse, enable_debug)
+            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, exclude_paths, recurse, enable_debug)
         
         # Assert
         self.assertEqual(result, expected_result_file)
@@ -181,14 +184,15 @@ class TestCdxGen(unittest.TestCase):
     def test_run_cdxgen_failure(self, mock_subprocess, mock_logger):
         # Arrange
         command_prefix = "/usr/local/bin/cdxgen"
-        exclude_types = ""
+        exclude_types = []
+        exclude_paths = []
         recurse = True
         enable_debug = False
         error_message = "Command execution failed"
         mock_subprocess.side_effect = Exception(error_message)
         
         # Act
-        result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, recurse, enable_debug)
+        result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, exclude_paths, recurse, enable_debug)
         
         # Assert
         self.assertIsNone(result)
@@ -199,7 +203,8 @@ class TestCdxGen(unittest.TestCase):
     def test_run_cdxgen_debug_mode_enabled(self, mock_logger, mock_subprocess):
         # Arrange
         command_prefix = "/usr/local/bin/cdxgen"
-        exclude_types = ""
+        exclude_types = []
+        exclude_paths = []
         recurse = True
         enable_debug = True
         mock_result = Mock(returncode=0, stdout="Debug stdout output", stderr="Debug stderr output")
@@ -208,7 +213,7 @@ class TestCdxGen(unittest.TestCase):
         
         # Act
         with patch('builtins.print') as mock_print:
-            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, recurse, enable_debug)
+            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, exclude_paths, recurse, enable_debug)
         
         # Assert
         self.assertEqual(result, expected_result_file)
@@ -233,7 +238,8 @@ class TestCdxGen(unittest.TestCase):
                 "CDXGEN_VERSION": "10.2.0",
                 "SLIM_BINARY": False,
                 "OUTPUT_FORMAT": "json",
-                "EXCLUDE_TYPES": "",
+                "EXCLUDE_TYPES": [],
+                "EXCLUDE_PATHS": [],
                 "RECURSE": True,
                 "DEBUG_PIPELINES": ["test_service", "another_service"]
             }
@@ -247,7 +253,7 @@ class TestCdxGen(unittest.TestCase):
         # Assert
         self.assertEqual(result, self.mock_components)
         mock_logger.info.assert_called_with(f"Enabling debug mode for pipeline: {self.service_name}")
-        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, "", True, True)
+        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, [], [], True, True)
 
     @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.get_list_component')
     @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.platform.system')
@@ -262,7 +268,8 @@ class TestCdxGen(unittest.TestCase):
                 "CDXGEN_VERSION": "10.2.0",
                 "SLIM_BINARY": False,
                 "OUTPUT_FORMAT": "json",
-                "EXCLUDE_TYPES": "",
+                "EXCLUDE_TYPES": [],
+                "EXCLUDE_PATHS": [],
                 "RECURSE": True,
                 "DEBUG_PIPELINES": ["other_service", "another_service"]
             }
@@ -275,7 +282,85 @@ class TestCdxGen(unittest.TestCase):
         
         # Assert
         self.assertEqual(result, self.mock_components)
-        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, "", True, False)
+        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, [], [], True, False)
+
+    @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.subprocess.run')
+    def test_run_cdxgen_with_exclude_types_list(self, mock_subprocess):
+        # Arrange
+        command_prefix = "/usr/local/bin/cdxgen"
+        exclude_types = ["npm", "pip"]
+        exclude_paths = []
+        recurse = True
+        enable_debug = False
+        mock_result = Mock(returncode=0, stdout="", stderr="")
+        mock_subprocess.return_value = mock_result
+        expected_result_file = f"{self.service_name}_SBOM.json"
+        expected_command = [command_prefix, self.artifact, "-o", expected_result_file, "--exclude-type", "npm", "--exclude-type", "pip"]
+        
+        # Act
+        with patch('builtins.print') as mock_print:
+            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, exclude_paths, recurse, enable_debug)
+        
+        # Assert
+        self.assertEqual(result, expected_result_file)
+        mock_subprocess.assert_called_once_with(
+            expected_command,
+            stdout=unittest.mock.ANY,
+            stderr=unittest.mock.ANY,
+            text=True
+        )
+
+    @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.subprocess.run')
+    def test_run_cdxgen_with_exclude_paths_list(self, mock_subprocess):
+        # Arrange
+        command_prefix = "/usr/local/bin/cdxgen"
+        exclude_types = []
+        exclude_paths = ["node_modules", "vendor"]
+        recurse = True
+        enable_debug = False
+        mock_result = Mock(returncode=0, stdout="", stderr="")
+        mock_subprocess.return_value = mock_result
+        expected_result_file = f"{self.service_name}_SBOM.json"
+        expected_command = [command_prefix, self.artifact, "-o", expected_result_file, "--exclude", "node_modules", "--exclude", "vendor"]
+        
+        # Act
+        with patch('builtins.print') as mock_print:
+            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, exclude_paths, recurse, enable_debug)
+        
+        # Assert
+        self.assertEqual(result, expected_result_file)
+        mock_subprocess.assert_called_once_with(
+            expected_command,
+            stdout=unittest.mock.ANY,
+            stderr=unittest.mock.ANY,
+            text=True
+        )
+
+    @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.subprocess.run')
+    def test_run_cdxgen_no_recurse(self, mock_subprocess):
+        # Arrange
+        command_prefix = "/usr/local/bin/cdxgen"
+        exclude_types = []
+        exclude_paths = []
+        recurse = False
+        enable_debug = False
+        mock_result = Mock(returncode=0, stdout="", stderr="")
+        mock_subprocess.return_value = mock_result
+        expected_result_file = f"{self.service_name}_SBOM.json"
+        expected_command = [command_prefix, self.artifact, "-o", expected_result_file, "--no-recurse"]
+        
+        # Act
+        with patch('builtins.print') as mock_print:
+            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, exclude_paths, recurse, enable_debug)
+        
+        # Assert
+        self.assertEqual(result, expected_result_file)
+        mock_subprocess.assert_called_once_with(
+            expected_command,
+            stdout=unittest.mock.ANY,
+            stderr=unittest.mock.ANY,
+            text=True
+        )
 
     @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.subprocess.run')
     def test_install_tool_unix_already_installed(self, mock_subprocess):


### PR DESCRIPTION
## Description

add exclude types and paths to cdxgen configs

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
