### PR TITLE
fix: downgrade dependency pyarrow

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -22,4 +22,4 @@ PyJWT==2.9.0
 sympy==1.13.3
 urllib3<2.0.0
 holidays==0.58
-pyarrow==21.0.0
+pyarrow==20.0.0


### PR DESCRIPTION
### Fix
Incompatibility to use wiht pyinstaller in architecture Linux aarch64 with pyarrow==21.0.0. pyinstaller hooks fail to collect submodules. it works ok with version 20.0.0

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
