### PR TITLE
fix(engine_iac): validate response checkov

### DIFF
--- a/tools/devsecops_engine_tools/engine_sast/engine_iac/src/infrastructure/driven_adapters/checkov/checkov_deserealizator.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_iac/src/infrastructure/driven_adapters/checkov/checkov_deserealizator.py
@@ -46,4 +46,6 @@ class CheckovDeserealizator:
                     )
                     list_open_findings.append(finding_open)
 
+            if "'error'" in str(result):
+                raise Exception(result.get("error"))
         return list_open_findings


### PR DESCRIPTION
## Description


### Fix
Setting to make the pipeline execution fail when an error occurs while running the scan with Checkov

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
