### PR TITLE
feat: add lifecycle options to cdxgen sbom gen

### DIFF
--- a/docs/Docusaurus/docs/modules/engine_core.md
+++ b/docs/Docusaurus/docs/modules/engine_core.md
@@ -118,7 +118,10 @@ Configuration of the driven adapters in the main layer and management of on/off 
             "EXCLUDE_TYPES": ["jar"],
             "EXCLUDE_PATHS": ["**/test/**"],
             "RECURSE": true,
-            "DEBUG_PIPELINES": ["pipeline_name1", "pipeline_name2"]
+            "DEBUG_PIPELINES": ["pipeline_name1", "pipeline_name2"],
+            "LIFECYCLE_PIPELINES": {
+                "pipeline_name1": "pre-build"
+            }
         }
     },
     "ENGINE_IAC": {

--- a/example_remote_config_local/engine_core/ConfigTool.json
+++ b/example_remote_config_local/engine_core/ConfigTool.json
@@ -98,7 +98,10 @@
             "EXCLUDE_TYPES": ["jar"],
             "EXCLUDE_PATHS": ["**/test/**"],
             "RECURSE": true,
-            "DEBUG_PIPELINES": ["pipeline_name1", "pipeline_name2"]
+            "DEBUG_PIPELINES": ["pipeline_name1", "pipeline_name2"],
+            "LIFECYCLE_PIPELINES": {
+                "pipeline_name1": "pre-build"
+            }
         }
     },
     "ENGINE_IAC": {

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/cdxgen/cdxgen.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/cdxgen/cdxgen.py
@@ -32,6 +32,7 @@ class CdxGen(SbomManagerGateway):
             recurse = config["CDXGEN"].get("RECURSE", True)
             install_deps = config["CDXGEN"].get("INSTALL_DEPENDENCIES", True)
             debug_pipelines = config["CDXGEN"].get("DEBUG_PIPELINES", [])
+            lifecycle_pipelines = config["CDXGEN"].get("LIFECYCLE_PIPELINES", {})
             
             enable_debug = service_name in debug_pipelines if debug_pipelines else False
             if enable_debug:
@@ -63,13 +64,13 @@ class CdxGen(SbomManagerGateway):
                 logger.warning(f"{os_platform} is not supported.")
                 return None
 
-            result_sbom = self._run_cdxgen(command_prefix, artifact, service_name, exclude_types, exclude_paths, recurse, install_deps, enable_debug)
+            result_sbom = self._run_cdxgen(command_prefix, artifact, service_name, exclude_types, exclude_paths, recurse, install_deps, lifecycle_pipelines, enable_debug)
             return get_list_component(result_sbom, config["CDXGEN"]["OUTPUT_FORMAT"])
         except Exception as e:
             logger.error(f"Error generating SBOM: {e}")
             return None
 
-    def _run_cdxgen(self, command_prefix, artifact, service_name, exclude_types, exclude_paths, recurse, install_deps, enable_debug=False):
+    def _run_cdxgen(self, command_prefix, artifact, service_name, exclude_types, exclude_paths, recurse, install_deps, lifecycle_pipelines, enable_debug=False):
         result_file = f"{service_name}_SBOM.json"
         command = [
             command_prefix,
@@ -89,6 +90,11 @@ class CdxGen(SbomManagerGateway):
                 command.extend(
                     ["--exclude", ex]
                 )
+
+        if lifecycle_pipelines.get(service_name):
+            command.extend(
+                ["--lifecycle", lifecycle_pipelines.get(service_name)]
+            )
         
         if not recurse:
             command.append(
@@ -97,7 +103,7 @@ class CdxGen(SbomManagerGateway):
         
         if not install_deps:
             command.append(
-                "--install-deps false"
+                "--no-install-deps"
             )
 
         try:

--- a/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/cdxgen/test_cdxgen.py
+++ b/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/cdxgen/test_cdxgen.py
@@ -20,7 +20,8 @@ class TestCdxGen(unittest.TestCase):
                 "EXCLUDE_TYPES": [],
                 "EXCLUDE_PATHS": [],
                 "RECURSE": True,
-                "DEBUG_PIPELINES": []
+                "DEBUG_PIPELINES": [],
+                "LIFECYCLE_PIPELINES": {}
             }
         }
         
@@ -32,7 +33,8 @@ class TestCdxGen(unittest.TestCase):
                 "EXCLUDE_TYPES": [],
                 "EXCLUDE_PATHS": [],
                 "RECURSE": True,
-                "DEBUG_PIPELINES": []
+                "DEBUG_PIPELINES": [],
+                "LIFECYCLE_PIPELINES": {}
             }
         }
         
@@ -61,7 +63,7 @@ class TestCdxGen(unittest.TestCase):
             "https://github.com/CycloneDX/cdxgen/releases/download/v10.2.0/cdxgen-linux-amd64",
             "cdxgen"
         )
-        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, [], [], True, True, False)
+        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, [], [], True, True, {}, False)
         mock_get_list_component.assert_called_once_with('test_service_SBOM.json', 'json')
 
     @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.get_list_component')
@@ -161,6 +163,7 @@ class TestCdxGen(unittest.TestCase):
         recurse = True
         install_deps = True
         enable_debug = False
+        lifecycle_pipelines = {}
         mock_result = Mock(returncode=0, stdout="", stderr="")
         mock_subprocess.return_value = mock_result
         expected_result_file = f"{self.service_name}_SBOM.json"
@@ -168,7 +171,7 @@ class TestCdxGen(unittest.TestCase):
         
         # Act
         with patch('builtins.print') as mock_print:
-            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, exclude_paths, recurse, install_deps, enable_debug)
+            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, exclude_paths, recurse, install_deps, lifecycle_pipelines, enable_debug)
         
         # Assert
         self.assertEqual(result, expected_result_file)
@@ -190,11 +193,12 @@ class TestCdxGen(unittest.TestCase):
         recurse = True
         install_deps = True
         enable_debug = False
+        lifecycle_pipelines = {}
         error_message = "Command execution failed"
         mock_subprocess.side_effect = Exception(error_message)
         
         # Act
-        result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, exclude_paths, recurse, install_deps, enable_debug)
+        result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, exclude_paths, recurse, install_deps, lifecycle_pipelines, enable_debug)
         
         # Assert
         self.assertIsNone(result)
@@ -210,13 +214,14 @@ class TestCdxGen(unittest.TestCase):
         recurse = True
         install_deps = True
         enable_debug = True
+        lifecycle_pipelines = {}
         mock_result = Mock(returncode=0, stdout="Debug stdout output", stderr="Debug stderr output")
         mock_subprocess.return_value = mock_result
         expected_result_file = f"{self.service_name}_SBOM.json"
         
         # Act
         with patch('builtins.print') as mock_print:
-            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, exclude_paths, recurse, install_deps, enable_debug)
+            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, exclude_paths, recurse, install_deps, lifecycle_pipelines, enable_debug)
         
         # Assert
         self.assertEqual(result, expected_result_file)
@@ -245,7 +250,8 @@ class TestCdxGen(unittest.TestCase):
                 "EXCLUDE_PATHS": [],
                 "RECURSE": True,
                 "INSTALL_DEPENDENCIES": False,
-                "DEBUG_PIPELINES": ["test_service", "another_service"]
+                "DEBUG_PIPELINES": ["test_service", "another_service"],
+                "LIFECYCLE_PIPELINES": {}
             }
         }
         
@@ -257,7 +263,7 @@ class TestCdxGen(unittest.TestCase):
         # Assert
         self.assertEqual(result, self.mock_components)
         mock_logger.info.assert_called_with(f"Enabling debug mode for pipeline: {self.service_name}")
-        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, [], [], True, False, True)
+        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, [], [], True, False, {}, True)
 
     @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.get_list_component')
     @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.platform.system')
@@ -275,7 +281,8 @@ class TestCdxGen(unittest.TestCase):
                 "EXCLUDE_TYPES": [],
                 "EXCLUDE_PATHS": [],
                 "RECURSE": True,
-                "DEBUG_PIPELINES": ["other_service", "another_service"]
+                "DEBUG_PIPELINES": ["other_service", "another_service"],
+                "LIFECYCLE_PIPELINES": {}
             }
         }
         
@@ -286,7 +293,7 @@ class TestCdxGen(unittest.TestCase):
         
         # Assert
         self.assertEqual(result, self.mock_components)
-        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, [], [], True, True, False)
+        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, [], [], True, True, {}, False)
 
     @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.subprocess.run')
     def test_run_cdxgen_with_exclude_types_list(self, mock_subprocess):
@@ -297,6 +304,7 @@ class TestCdxGen(unittest.TestCase):
         recurse = True
         install_deps = True
         enable_debug = False
+        lifecycle_pipelines = {}
         mock_result = Mock(returncode=0, stdout="", stderr="")
         mock_subprocess.return_value = mock_result
         expected_result_file = f"{self.service_name}_SBOM.json"
@@ -304,7 +312,7 @@ class TestCdxGen(unittest.TestCase):
         
         # Act
         with patch('builtins.print') as mock_print:
-            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, exclude_paths, recurse, install_deps, enable_debug)
+            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, exclude_paths, recurse, install_deps, lifecycle_pipelines, enable_debug)
         
         # Assert
         self.assertEqual(result, expected_result_file)
@@ -324,6 +332,7 @@ class TestCdxGen(unittest.TestCase):
         recurse = True
         install_deps = True
         enable_debug = False
+        lifecycle_pipelines = {}
         mock_result = Mock(returncode=0, stdout="", stderr="")
         mock_subprocess.return_value = mock_result
         expected_result_file = f"{self.service_name}_SBOM.json"
@@ -331,7 +340,7 @@ class TestCdxGen(unittest.TestCase):
         
         # Act
         with patch('builtins.print') as mock_print:
-            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, exclude_paths, recurse, install_deps, enable_debug)
+            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, exclude_paths, recurse, install_deps, lifecycle_pipelines, enable_debug)
         
         # Assert
         self.assertEqual(result, expected_result_file)
@@ -351,6 +360,7 @@ class TestCdxGen(unittest.TestCase):
         recurse = False
         enable_debug = False
         install_deps = True
+        lifecycle_pipelines = {}
         mock_result = Mock(returncode=0, stdout="", stderr="")
         mock_subprocess.return_value = mock_result
         expected_result_file = f"{self.service_name}_SBOM.json"
@@ -358,7 +368,7 @@ class TestCdxGen(unittest.TestCase):
         
         # Act
         with patch('builtins.print') as mock_print:
-            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, exclude_paths, recurse, install_deps, enable_debug)
+            result = self.cdxgen._run_cdxgen(command_prefix, self.artifact, self.service_name, exclude_types, exclude_paths, recurse, install_deps, lifecycle_pipelines, enable_debug)
         
         # Assert
         self.assertEqual(result, expected_result_file)


### PR DESCRIPTION
## Description

add lifecycle option to cdxgen sbom generation and fix install dependencies flag functionality

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
