### PR TITLE
feat: add override sbom tool property

### DIFF
--- a/docs/Docusaurus/docs/modules/engine_core.md
+++ b/docs/Docusaurus/docs/modules/engine_core.md
@@ -109,6 +109,10 @@ Configuration of the driven adapters in the main layer and management of on/off 
         "ENABLED": true,
         "TOOL": "SYFT|CDXGEN",
         "BRANCH_FILTER": [],
+        "TOOL_OVERRIDE_PIPELINES": {
+            "pipeline_exception_1": "SYFT",
+            "pipeline_exception_2": "CDXGEN"
+        },
         "SYFT": {
             "SYFT_VERSION": "1.17.0",
             "OUTPUT_FORMAT": "cyclonedx-json"

--- a/example_remote_config_local/engine_core/ConfigTool.json
+++ b/example_remote_config_local/engine_core/ConfigTool.json
@@ -89,6 +89,10 @@
         "ENABLED": true,
         "TOOL": "SYFT|CDXGEN",
         "BRANCH_FILTER": [],
+        "TOOL_OVERRIDE_PIPELINES": {
+            "pipeline_exception_1": "SYFT",
+            "pipeline_exception_2": "CDXGEN"
+        },
         "SYFT": {
             "SYFT_VERSION": "1.17.0",
             "OUTPUT_FORMAT": "cyclonedx-json"

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/entry_points/entry_point_core.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/entry_points/entry_point_core.py
@@ -28,7 +28,12 @@ def init_engine_core(
         args["remote_config_repo"], "/engine_core/ConfigTool.json", args["remote_config_branch"]
     )
     Printers.print_logo_tool(config_tool["BANNER"])
-    sbom_tool_gateway = sbom_tool_gateway.get(config_tool["SBOM_MANAGER"]["TOOL"].lower())
+
+    pipeline_name = devops_platform_gateway.get_variable("pipeline_name")
+    tool_override_pipelines = config_tool["SBOM_MANAGER"].get("TOOL_OVERRIDE_PIPELINES", {})
+    sbom_tool_name = tool_override_pipelines.get(pipeline_name, config_tool["SBOM_MANAGER"]["TOOL"])
+    
+    sbom_tool_gateway = sbom_tool_gateway.get(sbom_tool_name.lower())
 
     if config_tool[args["module"].upper()]["ENABLED"]:
         if args["module"] == "engine_risk":

--- a/tools/devsecops_engine_tools/engine_core/test/infrastructure/entry_points/test_entry_point_core.py
+++ b/tools/devsecops_engine_tools/engine_core/test/infrastructure/entry_points/test_entry_point_core.py
@@ -226,3 +226,71 @@ class TestEntryPointCore(unittest.TestCase):
             args,
             mock_scan_result,
         )
+
+    @mock.patch(
+        "devsecops_engine_tools.engine_core.src.infrastructure.entry_points.entry_point_core.HandleScan"
+    )
+    @mock.patch(
+        "devsecops_engine_tools.engine_core.src.infrastructure.entry_points.entry_point_core.BreakBuild"
+    )
+    def test_init_engine_core_with_sbom_tool_override(
+        self,
+        mock_break_build,
+        mock_handle_scan
+    ):
+        """Test that TOOL_OVERRIDE_PIPELINES correctly overrides the default SBOM tool"""
+        # Set up mock config with tool override
+        mock_config_tool = {
+            "BANNER": "DevSecOps Engine Tools",
+            "WARNING_RELEASE": False,
+            "ENGINE_IAC": {"ENABLED": "true", "TOOL": "checkov"},
+            "SBOM_MANAGER": {
+                "TOOL": "CDXGEN",  # Default tool
+                "TOOL_OVERRIDE_PIPELINES": {
+                    "my_special_pipeline": "SYFT"  # Override for specific pipeline
+                }
+            }
+        }
+        mock_findings_list = []
+        mock_input_core = {}
+        mock_scan_result = {}
+
+        mock_devops_platform_gateway = mock.Mock()
+        mock_remote_config_source_gateway = mock.Mock()
+        mock_sbom_tool_gateway = mock.Mock()
+
+        # Configure mocks
+        mock_devops_platform_gateway.get_variable.return_value = "my_special_pipeline"
+        mock_remote_config_source_gateway.get_remote_config.return_value = mock_config_tool
+        mock_sbom_tool_gateway.get.return_value = mock.Mock()
+
+        mock_handle_scan.return_value.process.return_value = (
+            mock_findings_list,
+            mock_input_core,
+        )
+        mock_break_build.return_value.process.return_value = mock_scan_result
+
+        args = {
+            "remote_config_repo": "https://github.com/example/repo",
+            "module": "engine_iac",
+            "send_metrics": "false",
+            "remote_config_branch": ""
+        }
+
+        # Call the function
+        init_engine_core(
+            vulnerability_management_gateway=mock.Mock(),
+            secrets_manager_gateway=mock.Mock(),
+            devops_platform_gateway=mock_devops_platform_gateway,
+            remote_config_source_gateway=mock_remote_config_source_gateway,
+            print_table_gateway=mock.Mock(),
+            metrics_manager_gateway=mock.Mock(),
+            sbom_tool_gateway=mock_sbom_tool_gateway,
+            args=args,
+        )
+
+        # Assert that get_variable was called to get pipeline name
+        mock_devops_platform_gateway.get_variable.assert_called_with("pipeline_name")
+        
+        # Assert that the SBOM tool was selected with the override (SYFT instead of CDXGEN)
+        mock_sbom_tool_gateway.get.assert_called_once_with("syft")


### PR DESCRIPTION
## Description

add override sbom tool property to change between tools depending on the project

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
