### PR TITLE
feat(defect_dojo): optional flag get exact product

### DIFF
--- a/docs/Docusaurus/docs/modules/engine_core.md
+++ b/docs/Docusaurus/docs/modules/engine_core.md
@@ -39,6 +39,7 @@ Configuration of the driven adapters in the main layer and management of on/off 
             "PRINT_DOMAIN": "",
             "LIMITS_QUERY": 100,
             "MAX_RETRIES_QUERY": 5,
+            "GET_EXACT_PRODUCT": false,
             "TOOL_SCM_MAPPING": {
                 "DEFAULT": 2,
                 "TFSGIT": 2,
@@ -246,6 +247,7 @@ Configuration of the driven adapters in the main layer and management of on/off 
         - PRINT_DOMAIN: Dominio to print
         - LIMITS_QUERY: Query limit for platform queries.
         - MAX_RETRIES_QUERY: Maximum number of retry attempts for queries to the platform
+        - GET_EXACT_PRODUCT: optional flag. Ensure product get from defect dojo before request is exact match otherwise use default behavior include match
         - **TOOL_SCM_MAPPING**: Mapping between the source code management (SCM) tool and its corresponding identifier in DefectDojo.  
             - **DEFAULT**: Default SCM tool identifier.
             - **TFSGIT**: Identifier for Azure DevOps (TFS Git) repositories.

--- a/example_remote_config_local/engine_core/ConfigTool.json
+++ b/example_remote_config_local/engine_core/ConfigTool.json
@@ -19,6 +19,7 @@
             "PRINT_DOMAIN": "",
             "LIMITS_QUERY": 100,
             "MAX_RETRIES_QUERY": 5,
+            "GET_EXACT_PRODUCT": false,
             "TOOL_SCM_MAPPING": {
                 "DEFAULT": 2,
                 "TFSGIT": 2,

--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/defect_dojo/defect_dojo.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/defect_dojo/defect_dojo.py
@@ -520,6 +520,9 @@ class DefectDojoPlatform(VulnerabilityManagementGateway):
             "reimport_scan": vulnerability_management.config_tool[
                 "VULNERABILITY_MANAGER"
             ]["DEFECT_DOJO"]["REIMPORT_SCAN"],
+            "get_exact_product": vulnerability_management.config_tool[
+                "VULNERABILITY_MANAGER"
+            ]["DEFECT_DOJO"].get("GET_EXACT_PRODUCT", False),
             "tool_sonarqube_configuration": (
                 tool_sonar_conf_mapping[
                     vulnerability_management.sonar_instance.upper()

--- a/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/defect_dojo/test_defect_dojo.py
+++ b/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/defect_dojo/test_defect_dojo.py
@@ -173,6 +173,7 @@ class TestDefectDojoPlatform(unittest.TestCase):
                 tags=["engine_iac_k8s"],
                 test_title="engine_iac_k8s",
                 reimport_scan=True,
+                get_exact_product=False,
             )
 
     def test_send_vulnerability_management_exception(self):
@@ -332,6 +333,7 @@ class TestDefectDojoPlatform(unittest.TestCase):
                 expression="regex",
                 test_title="engine_iac_k8s",
                 reimport_scan=True,
+                get_exact_product=False,
             )
             self.assertEqual(result, "cmdb_request_result")
 
@@ -438,6 +440,7 @@ class TestDefectDojoPlatform(unittest.TestCase):
                     "expression": "regex",
                     "test_title": "engine_iac_k8s_test_2",
                     "reimport_scan": True,
+                    "get_exact_product": False,
                 }
             )
             self.assertEqual(result, "import_scan_request_result")

--- a/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/request_objects/import_scan.py
+++ b/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/request_objects/import_scan.py
@@ -60,6 +60,7 @@ class ImportScanRequest:
     expression: str = ""
     url: str = ""
     reimport_scan: bool = None
+    get_exact_product: bool = None
     test_title: str = ""
 
     @classmethod

--- a/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/serializers/import_scan.py
+++ b/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/serializers/import_scan.py
@@ -226,6 +226,7 @@ class ImportScanSerializer(Schema):
     # regulare expression
     expression = fields.Str(required=True)
     reimport_scan = fields.Bool(required=False)
+    get_exact_product = fields.Bool(required=False)
 
     @post_load
     def make_cmdb(self, data, **kwargs):

--- a/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/user_case/import_scan.py
+++ b/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/user_case/import_scan.py
@@ -75,9 +75,10 @@ class ImportScanUserCase:
             raise ApiError(log)
 
         logger.debug(f"Match {request.scan_type}")
-        products = self.__rest_product.get_products({"name": request.product_name})
+        searchTypeKey = "name_exact" if request.get_exact_product is True else "name"
+        products = self.__rest_product.get_products({searchTypeKey: request.product_name})
         if len(products.results) == 0 and request.product_name != "Orphan_Product":
-            products = self.__rest_product.get_products({"name": request.code_app})
+            products = self.__rest_product.get_products({searchTypeKey: request.code_app})
         if len(products.results) > 0:
             product_id = products.results[0].id
             request.product_name = products.results[0].name


### PR DESCRIPTION
## Description

- Optional flag to ensure get exact product name before import request instead of searching for include

Examples:

1. Current Beahvior: 

If current products name in defect dojo are:
- product1
- duct1

and analizing product is "duct1" get product is "product1"

2. When GET_EXACT_PRODUCT flag is set:
If current products name in defect dojo are:
- product1
- duct1

and analizing product is "duct1" get product is "duct1"

so works better in case product name is short name or abbreviation

### Fix
When not set or  set as False continues with default behavior for inclusive search


## Checklist:

- [X] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my feature, policy, or fix is effective and works
- [X] New and existing tests pass locally with my changes
