### PR TITLE
feat(engine_dependencies): Trivy support for Linux and MacOs Arm64

### DIFF
--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/cdxgen/cdxgen.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/cdxgen/cdxgen.py
@@ -40,18 +40,26 @@ class CdxGen(SbomManagerGateway):
                 os.environ["CDXGEN_DEBUG_MODE"] = "debug"
 
             os_platform = platform.system()
+            os_architecture = platform.machine()
+
             base_url = (
                 f"https://github.com/CycloneDX/cdxgen/releases/download/v{cdxgen_version}/"
             )
-
+            
             command_prefix = "cdxgen"
             if os_platform == "Linux":
-                file = f"cdxgen-linux-amd64{slim}"
+                if os_architecture == "aarch64":
+                    file = f"cdxgen-linux-arm64{slim}"
+                else:
+                    file = f"cdxgen-linux-amd64{slim}"
                 command_prefix = self._install_tool_unix(
                     file, base_url + file, command_prefix
                 )
             elif os_platform == "Darwin":
-                file = f"cdxgen-darwin-amd64{slim}"
+                if os_architecture == "arm64":
+                    file = f"cdxgen-darwin-arm64{slim}"
+                else:
+                    file = f"cdxgen-darwin-amd64{slim}"
                 command_prefix = self._install_tool_unix(
                     file, base_url + file, command_prefix
                 )

--- a/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/cdxgen/test_cdxgen.py
+++ b/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/cdxgen/test_cdxgen.py
@@ -66,6 +66,30 @@ class TestCdxGen(unittest.TestCase):
         mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, [], [], True, True, {}, False)
         mock_get_list_component.assert_called_once_with('test_service_SBOM.json', 'json')
 
+    @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.platform.machine')
+    @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.get_list_component')
+    @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.platform.system')
+    def test_get_components_linux_success_arm64(self, mock_platform, mock_get_list_component, mock_machine):
+        # Arrange
+        mock_platform.return_value = "Linux"
+        mock_machine.return_value = "aarch64"
+        mock_get_list_component.return_value = self.mock_components
+        
+        with patch.object(self.cdxgen, '_install_tool_unix', return_value='/usr/local/bin/cdxgen') as mock_install:
+            with patch.object(self.cdxgen, '_run_cdxgen', return_value='test_service_SBOM.json') as mock_run:
+                # Act
+                result = self.cdxgen.get_components(self.artifact, self.mock_config, self.service_name)
+        
+        # Assert
+        self.assertEqual(result, self.mock_components)
+        mock_install.assert_called_once_with(
+            "cdxgen-linux-arm64",
+            "https://github.com/CycloneDX/cdxgen/releases/download/v10.2.0/cdxgen-linux-arm64",
+            "cdxgen"
+        )
+        mock_run.assert_called_once_with('/usr/local/bin/cdxgen', self.artifact, self.service_name, [], [], True, True, {}, False)
+        mock_get_list_component.assert_called_once_with('test_service_SBOM.json', 'json')
+
     @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.get_list_component')
     @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.platform.system')
     def test_get_components_linux_slim_binary(self, mock_platform, mock_get_list_component):
@@ -103,6 +127,28 @@ class TestCdxGen(unittest.TestCase):
         mock_install.assert_called_once_with(
             "cdxgen-darwin-amd64",
             "https://github.com/CycloneDX/cdxgen/releases/download/v10.2.0/cdxgen-darwin-amd64",
+            "cdxgen"
+        )
+
+    @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.platform.machine')
+    @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.get_list_component')
+    @patch('devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.cdxgen.cdxgen.platform.system')
+    def test_get_components_darwin_success_arm64(self, mock_platform, mock_get_list_component, mock_machine):
+        # Arrange
+        mock_platform.return_value = "Darwin"
+        mock_machine.return_value = "arm64"
+        mock_get_list_component.return_value = self.mock_components
+        
+        with patch.object(self.cdxgen, '_install_tool_unix', return_value='/usr/local/bin/cdxgen') as mock_install:
+            with patch.object(self.cdxgen, '_run_cdxgen', return_value='test_service_SBOM.json') as mock_run:
+                # Act
+                result = self.cdxgen.get_components(self.artifact, self.mock_config, self.service_name)
+        
+        # Assert
+        self.assertEqual(result, self.mock_components)
+        mock_install.assert_called_once_with(
+            "cdxgen-darwin-arm64",
+            "https://github.com/CycloneDX/cdxgen/releases/download/v10.2.0/cdxgen-darwin-arm64",
             "cdxgen"
         )
 

--- a/tools/devsecops_engine_tools/engine_utilities/test/trivy_utils/infrastructure/test_trivy_manager_scan_utils.py
+++ b/tools/devsecops_engine_tools/engine_utilities/test/trivy_utils/infrastructure/test_trivy_manager_scan_utils.py
@@ -107,6 +107,25 @@ def test_identify_os_and_install_linux(trivy_utils_instance):
         mock_install.assert_called_with(expected_file, expected_url, "trivy")
         assert result == "./trivy"
 
+def test_identify_os_and_install_linux_arm64(trivy_utils_instance):
+    """Test identify_os_and_install for Linux platform"""
+    with patch("platform.system") as mock_platform, patch("platform.architecture") as mock_arch, patch(
+        "devsecops_engine_tools.engine_utilities.trivy_utils.infrastructure.driven_adapters.trivy_manager_scan_utils.TrivyManagerScanUtils._install_tool"
+    ) as mock_install, patch("platform.machine") as mock_machine:
+        mock_platform.return_value = "Linux"
+        mock_arch.return_value = ("64bit", "")
+        mock_machine.return_value = "aarch64"
+        mock_install.return_value = "./trivy"
+        version = "1.2.3"
+        
+        result = trivy_utils_instance.identify_os_and_install(version)
+        
+        expected_file = f"trivy_{version}_Linux-ARM64.tar.gz"
+        expected_url = f"https://github.com/aquasecurity/trivy/releases/download/v{version}/{expected_file}"
+        mock_install.assert_called_with(expected_file, expected_url, "trivy")
+        assert result == "./trivy"
+
+
 
 def test_identify_os_and_install_darwin(trivy_utils_instance):
     """Test identify_os_and_install for macOS platform"""
@@ -125,6 +144,23 @@ def test_identify_os_and_install_darwin(trivy_utils_instance):
         mock_install.assert_called_with(expected_file, expected_url, "trivy")
         assert result == "./trivy"
 
+def test_identify_os_and_install_darwin_arm64(trivy_utils_instance):
+    """Test identify_os_and_install for macOS platform"""
+    with patch("platform.system") as mock_platform, patch("platform.architecture") as mock_arch, patch(
+        "devsecops_engine_tools.engine_utilities.trivy_utils.infrastructure.driven_adapters.trivy_manager_scan_utils.TrivyManagerScanUtils._install_tool"
+    ) as mock_install, patch("platform.machine") as mock_machine:
+        mock_platform.return_value = "Darwin"
+        mock_arch.return_value = ("64bit", "")
+        mock_machine.return_value = "arm64"
+        mock_install.return_value = "./trivy"
+        version = "1.2.3"
+        
+        result = trivy_utils_instance.identify_os_and_install(version)
+        
+        expected_file = f"trivy_{version}_macOS-ARM64.tar.gz"
+        expected_url = f"https://github.com/aquasecurity/trivy/releases/download/v{version}/{expected_file}"
+        mock_install.assert_called_with(expected_file, expected_url, "trivy")
+        assert result == "./trivy"
 
 def test_identify_os_and_install_windows(trivy_utils_instance):
     """Test identify_os_and_install for Windows platform"""

--- a/tools/devsecops_engine_tools/engine_utilities/trivy_utils/infrastructure/driven_adapters/trivy_manager_scan_utils.py
+++ b/tools/devsecops_engine_tools/engine_utilities/trivy_utils/infrastructure/driven_adapters/trivy_manager_scan_utils.py
@@ -12,14 +12,22 @@ class TrivyManagerScanUtils():
     def identify_os_and_install(self, trivy_version):
         os_platform = platform.system()
         arch_platform = platform.architecture()[0]
+        os_architecture = platform.machine()
         base_url = f"https://github.com/aquasecurity/trivy/releases/download/v{trivy_version}/"
 
         command_prefix = "trivy"
+        
         if os_platform == "Linux":
-            file=f"trivy_{trivy_version}_Linux-{arch_platform}.tar.gz"
+            if os_architecture == "aarch64":
+                file = f"trivy_{trivy_version}_Linux-ARM64.tar.gz"
+            else:
+                file=f"trivy_{trivy_version}_Linux-{arch_platform}.tar.gz"
             command_prefix = self._install_tool(file, base_url+file, "trivy")
         elif os_platform == "Darwin":
-            file=f"trivy_{trivy_version}_macOS-{arch_platform}.tar.gz"
+            if os_architecture == "arm64":
+                file = f"trivy_{trivy_version}_macOS-ARM64.tar.gz"
+            else:
+                file=f"trivy_{trivy_version}_macOS-{arch_platform}.tar.gz"
             command_prefix = self._install_tool(file, base_url+file, "trivy")
         elif os_platform == "Windows":
             file=f"trivy_{trivy_version}_windows-{arch_platform}.zip"


### PR DESCRIPTION
## Description

Added Support for Downloading proper ARM64 binary for Trivy and Cdxgen so it is posible to run engine dependencies with Trivy tool in ARM64 host

- Support added: 
Linux ARM64 (aarch64)
MacOs Darwin (arm64)

Note: Trivy does not provide Windows ARM64 binary so support is not added to the engine

### Fix
If host is not amr64 arch logic follow current behavior

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
