### PR TITLE
feat(engine_utilities): Use remote_config_source to find cmdb_mapping

### DIFF
--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/defect_dojo/defect_dojo.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/defect_dojo/defect_dojo.py
@@ -560,6 +560,12 @@ class DefectDojoPlatform(VulnerabilityManagementGateway):
                 cmdb_request_response=vulnerability_management.config_tool[
                     "VULNERABILITY_MANAGER"
                 ]["DEFECT_DOJO"]["CMDB"]["CMDB_REQUEST_RESPONSE"],
+                remote_config_source=vulnerability_management.dict_args.get("remote_config_source"),
+                remote_config_repo=vulnerability_management.dict_args.get("remote_config_repo"),
+                remote_config_path=vulnerability_management.config_tool["VULNERABILITY_MANAGER"][
+                    "DEFECT_DOJO"
+                ]["CMDB"]["CMDB_MAPPING_PATH"],
+                remote_config_branch=vulnerability_management.dict_args.get("remote_config_branch"),
                 **common_fields,
             )
         else:

--- a/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/defect_dojo/test_defect_dojo.py
+++ b/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/defect_dojo/test_defect_dojo.py
@@ -31,6 +31,9 @@ class TestDefectDojoPlatform(unittest.TestCase):
             "token_cmdb": "token2",
             "module": "engine_iac",
             "platform": ["k8s"],
+            "remote_config_source": "github",
+            "remote_config_repo": "remote_config",
+            "remote_config_branch": None,
         }
         self.vulnerability_management.secret_tool = {
             "token_defect_dojo": "token3",
@@ -174,6 +177,10 @@ class TestDefectDojoPlatform(unittest.TestCase):
                 test_title="engine_iac_k8s",
                 reimport_scan=True,
                 get_exact_product=False,
+                remote_config_source="github",
+                remote_config_repo="remote_config",
+                remote_config_path="mapping_path",
+                remote_config_branch=None,
             )
 
     def test_send_vulnerability_management_exception(self):
@@ -210,6 +217,15 @@ class TestDefectDojoPlatform(unittest.TestCase):
         self.vulnerability_management.branch_tag = "trunk"
         self.vulnerability_management.commit_hash = "commit_hash"
         self.vulnerability_management.environment = "dev"
+        self.vulnerability_management.dict_args = {
+            "token_vulnerability_management": "token1",
+            "token_cmdb": "token2",
+            "module": "engine_iac",
+            "platform": ["k8s"],
+            "remote_config_source": "github",
+            "remote_config_repo": "remote_config",
+            "remote_config_branch": None,
+        }
 
         self.vulnerability_management.config_tool = {
             "VULNERABILITY_MANAGER": {
@@ -334,6 +350,10 @@ class TestDefectDojoPlatform(unittest.TestCase):
                 test_title="engine_iac_k8s",
                 reimport_scan=True,
                 get_exact_product=False,
+                remote_config_source="github",
+                remote_config_repo="remote_config",
+                remote_config_path="mapping_path",
+                remote_config_branch=None,
             )
             self.assertEqual(result, "cmdb_request_result")
 

--- a/tools/devsecops_engine_tools/engine_utilities/defect_dojo/applications/connect.py
+++ b/tools/devsecops_engine_tools/engine_utilities/defect_dojo/applications/connect.py
@@ -3,7 +3,9 @@ from devsecops_engine_tools.engine_utilities.defect_dojo.domain.request_objects.
 from devsecops_engine_tools.engine_utilities.defect_dojo.domain.serializers.import_scan import ImportScanSerializer
 from devsecops_engine_tools.engine_utilities.defect_dojo.domain.user_case.cmdb import CmdbUserCase
 from devsecops_engine_tools.engine_utilities.defect_dojo.infraestructure.driver_adapters.cmdb import CmdbRestConsumer
-from devsecops_engine_tools.engine_utilities.azuredevops.infrastructure.azure_devops_api import AzureDevopsApi
+from devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.azure.azure_devops import AzureDevops
+from devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.github.github_actions import GithubActions
+from devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.runtime_local.runtime_local import RuntimeLocal
 from devsecops_engine_tools.engine_utilities.utils.session_manager import SessionManager
 
 
@@ -20,16 +22,13 @@ class Connect:
                 session=SessionManager(),
             )
 
-            utils_azure = AzureDevopsApi(
-                personal_access_token=request.personal_access_token,
-                project_remote_config=request.project_remote_config,
-                organization_url=request.organization_url,
-                compact_remote_config_url=request.compact_remote_config_url,
-                repository_id=request.repository_id,
-                remote_config_path=request.remote_config_path,
-            )
+            remote_config_source_gateway = {
+                "azure": AzureDevops(),
+                "github": GithubActions(),
+                "local": RuntimeLocal()
+            }.get(request.remote_config_source.lower())
 
-            uc = CmdbUserCase(rest_consumer_cmdb=rc, utils_azure=utils_azure, expression=request.expression)
+            uc = CmdbUserCase(rest_consumer_cmdb=rc, remote_config_source_gateway=remote_config_source_gateway, expression=request.expression)
             response = uc.execute(request)
         except Exception as e:
             return e
@@ -37,5 +36,5 @@ class Connect:
         return response
     
     def get_code_app(engagement_name, expression):
-        uc = CmdbUserCase(rest_consumer_cmdb=None, utils_azure=None, expression=expression)
+        uc = CmdbUserCase(rest_consumer_cmdb=None, remote_config_source_gateway=None, expression=expression)
         return uc.get_code_app(engagement_name)

--- a/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/request_objects/import_scan.py
+++ b/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/request_objects/import_scan.py
@@ -52,7 +52,10 @@ class ImportScanRequest:
     organization_url: str = ""
     personal_access_token: str = ""
     repository_id: str = ""
+    remote_config_source: str = ""
+    remote_config_repo: str = ""
     remote_config_path: str = ""
+    remote_config_branch: str = ""
     project_remote_config: str = ""
     cmdb_mapping: dict = None
     product_type_name_mapping: dict = None

--- a/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/serializers/import_scan.py
+++ b/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/serializers/import_scan.py
@@ -221,7 +221,10 @@ class ImportScanSerializer(Schema):
     organization_url = fields.Str(required=False)
     personal_access_token = fields.Str(required=False)
     repository_id = fields.Str(required=False)
-    remote_config_path = fields.Str(required=False)
+    remote_config_source = fields.Str(required=True)
+    remote_config_repo = fields.Str(required=True)
+    remote_config_path = fields.Str(required=True)
+    remote_config_branch = fields.Str(required=False)
     project_remote_config = fields.Str(required=False)
     # regulare expression
     expression = fields.Str(required=True)

--- a/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/user_case/cmdb.py
+++ b/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/user_case/cmdb.py
@@ -1,4 +1,5 @@
 import re
+from devsecops_engine_tools.engine_core.src.domain.model.gateway.devops_platform_gateway import DevopsPlatformGateway
 from devsecops_engine_tools.engine_utilities.utils.api_error import ApiError
 from devsecops_engine_tools.engine_utilities.defect_dojo.infraestructure.driver_adapters.cmdb import CmdbRestConsumer
 from devsecops_engine_tools.engine_utilities.defect_dojo.domain.request_objects.import_scan import ImportScanRequest
@@ -10,15 +11,18 @@ logger = MyLogger.__call__(**SETTING_LOGGER).get_logger()
 
 
 class CmdbUserCase:
-    def __init__(self, rest_consumer_cmdb: CmdbRestConsumer, utils_azure: AzureDevopsApi, expression) -> None:
+    def __init__(self, rest_consumer_cmdb: CmdbRestConsumer, remote_config_source_gateway: DevopsPlatformGateway, expression) -> None:
         self.__rc_cmdb = rest_consumer_cmdb
-        self.__utils_azure = utils_azure
+        self.__remote_config_source_gateway = remote_config_source_gateway
         self.__expression = expression
 
     def execute(self, request: ImportScanRequest) -> ImportScanRequest:
         # Connection config map
-        connection = self.__utils_azure.get_azure_connection()
-        remote_config = self.__utils_azure.get_remote_json_config(connection=connection)
+        remote_config = self.__remote_config_source_gateway.get_remote_config(
+            request.remote_config_repo,
+            request.remote_config_path,
+            request.remote_config_branch,
+        )
 
         # regular exprecion
         request.code_app = self.get_code_app(request.engagement_name)

--- a/tools/devsecops_engine_tools/engine_utilities/defect_dojo/test/domain/user_case/test_connect_cmdb.py
+++ b/tools/devsecops_engine_tools/engine_utilities/defect_dojo/test/domain/user_case/test_connect_cmdb.py
@@ -10,7 +10,6 @@ from devsecops_engine_tools.engine_utilities.defect_dojo.infraestructure.driver_
 from devsecops_engine_tools.engine_utilities.defect_dojo.domain.request_objects.import_scan import (
     ImportScanRequest,
 )
-from devsecops_engine_tools.engine_utilities.azuredevops.infrastructure.azure_devops_api import AzureDevopsApi
 from devsecops_engine_tools.engine_utilities.defect_dojo.domain.user_case.cmdb import CmdbUserCase
 
 
@@ -80,7 +79,10 @@ def test_execute(engagement_name, obj_cmdb):
         "personal_access_token": "tokenxxxx12354564",
         "product_name": "test product name",
         "repository_id": "repositoryid_or_name_repository",
+        "remote_config_source": "azure",
+        "remote_config_repo": "repositoryid_or_name_repository",
         "remote_config_path": "/defect_dojo/cmdb_mapping.json",
+        "remote_config_branch": "",
         "project_remote_config": "Vicepresidencia Servicios de Tecnología",
         "token_cmdb": "123456789",
         "host_cmdb": "http://localhost:8000",
@@ -107,28 +109,15 @@ def test_execute(engagement_name, obj_cmdb):
     mock_rc = mock_rest_consumer_cmdb(request, token="91qewuro9quowedafj", host="https://localhost:8000")
     # response file contect json
     file_content = [b'{"key": "value"}']
-    # mock git client
-    mock_git_client = MagicMock()
-    mock_git_client.get_item_text.return_value = file_content
-    # mock conecction
-    mock_connection = MagicMock()
-    mock_connection.clients.get_git_client.return_value = mock_git_client
-    # mock class azureDevopsApi
-    mock_utils_azure = MagicMock(spec=AzureDevopsApi)
-    mock_utils_azure.get_azure_connection.return_value = mock_connection
-    # mock get_remote_json_config
-    mock_utils_azure.get_remote_json_config.return_value = {
+    # mock remote config source gateway
+    mock_remote_config_source_gateway = MagicMock()
+    mock_remote_config_source_gateway.get_remote_config.return_value = {
         "types_product": {"ORPHAN_PRODUCT_TYPE": "ORPHAN_PRODUCT_TYPE"}
     }
-    AzureDevopsApi(
-        personal_access_token="asjfdiajf",
-        project_remote_config="project remote test",
-        organization_url="http://organization_url/",
-    )
     mock_rc.get_product_info.return_value = obj_cmdb
     uc = CmdbUserCase(
         rest_consumer_cmdb=mock_rc,
-        utils_azure=mock_utils_azure,
+        remote_config_source_gateway=mock_remote_config_source_gateway,
         expression=r"((AUD|AP|CLD|USR|OPS|ASN|AW|NU|EUC|IS)\d+)",
     )
 
@@ -142,7 +131,7 @@ def test_execute(engagement_name, obj_cmdb):
 @pytest.mark.parametrize("engagement_name", [("engament_name")])
 def test_get_code_app(engagement_name):
     uc = CmdbUserCase(
-        rest_consumer_cmdb=None, utils_azure=None, expression=r"((AUD|AP|CLD|USR|OPS|ASN|AW|NU|EUC|IS)\d+)_"
+        rest_consumer_cmdb=None, remote_config_source_gateway=None, expression=r"((AUD|AP|CLD|USR|OPS|ASN|AW|NU|EUC|IS)\d+)_"
     )
     code_app = uc.get_code_app(engagement_name)
     assert code_app == ""


### PR DESCRIPTION
## Description

When establishing the connection to the CMDB, Azure is taken by default as the storage source for the cmdb_mapping. The necessary changes are made so that it also uses GitHub and local storage


## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
