### PR TITLE
feat(defect_dojo): add field to parametrize code app

### DIFF
--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/defect_dojo/defect_dojo.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/defect_dojo/defect_dojo.py
@@ -584,9 +584,12 @@ class DefectDojoPlatform(VulnerabilityManagementGateway):
         }
 
         if use_cmdb:
-            cmdb_mapping = vulnerability_management.config_tool[
-                "VULNERABILITY_MANAGER"
-            ]["DEFECT_DOJO"]["CMDB"]["CMDB_MAPPING"]
+            cmdb_config = vulnerability_management.config_tool["VULNERABILITY_MANAGER"]["DEFECT_DOJO"]["CMDB"]
+            cmdb_mapping = cmdb_config["CMDB_MAPPING"]
+            
+            if variable_code_app := cmdb_config.get("VARIABLE_CODE_APP"):
+                common_fields["variable_code_app"] = variable_code_app
+            
             request = Connect.cmdb(
                 generate_auth_cmdb=vulnerability_management.config_tool["VULNERABILITY_MANAGER"]["DEFECT_DOJO"]["CMDB"]["GENERATE_AUTH_CMDB"],
                 auth_cmdb_request_response=vulnerability_management.config_tool[

--- a/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/request_objects/import_scan.py
+++ b/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/request_objects/import_scan.py
@@ -59,6 +59,7 @@ class ImportScanRequest:
     project_remote_config: str = ""
     cmdb_mapping: dict = None
     product_type_name_mapping: dict = None
+    variable_code_app: str = ""
     compact_remote_config_url: str = None
     expression: str = ""
     url: str = ""

--- a/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/serializers/import_scan.py
+++ b/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/serializers/import_scan.py
@@ -216,6 +216,7 @@ class ImportScanSerializer(Schema):
     host_defect_dojo = fields.Str(required=True)
     cmdb_mapping = fields.Dict(required=False)
     product_type_name_mapping = fields.Dict(required=False)
+    variable_code_app = fields.Str(required=False)
     # Config remote credential
     compact_remote_config_url = fields.Str(required=False)
     organization_url = fields.Str(required=False)

--- a/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/user_case/cmdb.py
+++ b/tools/devsecops_engine_tools/engine_utilities/defect_dojo/domain/user_case/cmdb.py
@@ -1,4 +1,5 @@
 import re
+import os
 from devsecops_engine_tools.engine_core.src.domain.model.gateway.devops_platform_gateway import DevopsPlatformGateway
 from devsecops_engine_tools.engine_utilities.utils.api_error import ApiError
 from devsecops_engine_tools.engine_utilities.defect_dojo.infraestructure.driver_adapters.cmdb import CmdbRestConsumer
@@ -24,8 +25,11 @@ class CmdbUserCase:
             request.remote_config_branch,
         )
 
-        # regular exprecion
-        request.code_app = self.get_code_app(request.engagement_name)
+        request.code_app = (
+            os.environ.get(request.variable_code_app)
+            if request.variable_code_app
+            else self.get_code_app(request.engagement_name)
+        )
 
         # connect cmdb
         product_data = self.__rc_cmdb.get_product_info(request)


### PR DESCRIPTION
## Description

The contribution consists of decoupling the use of the pipeline name to extract the application code. To achieve this, an additional and optional field is added to the engine_core remote config, called VARIABLE_CODE_APP.

Use cases:
1. If you want the CMDB to be queried using the pipeline name, the field must not be added to the remote config.

2. If you want to use a variable that contains the application code in order to avoid relying on the pipeline name, you must add the key "VARIABLE_CODE_APP".

The value of this key must be the name of the variable that contains the application code.

Example:
The following variable is defined in the pipeline:
VARIABLE_WITH_CODE_APP=CODE_APP_123

Then, in the engine_core remote config, it should look something like this:
```
{
   "VULNERABILITY_MANAGER":{
      "DEFECT_DOJO":{
         "CMDB":{
            "VARIABLE_CODE_APP":"VARIABLE_WITH_CODE_APP"
         }
      }
   }
}
```

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
