### PR TITLE
feat: show logs in trivy engine container failed executions

### DIFF
--- a/tools/devsecops_engine_tools/engine_sca/engine_container/src/infrastructure/driven_adapters/trivy_tool/trivy_manager_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/src/infrastructure/driven_adapters/trivy_tool/trivy_manager_scan.py
@@ -50,9 +50,7 @@ class TrivyScan(ToolGateway):
             return result_file
 
         except subprocess.CalledProcessError as e:
-            logger.error(f"Error during image scan of {image_name}: {e}")
-            logger.error(f"Command stdout: {e.stdout}")
-            logger.error(f"Command stderr: {e.stderr}")
+            logger.error(f"Error during image scan of {image_name}: {e} \nCommand stdout: {e.stdout} \nCommand stderr: {e.stderr}")
         except Exception as e:
             logger.error(f"Unexpected error during image scan of {image_name}: {e}")
 
@@ -87,9 +85,7 @@ class TrivyScan(ToolGateway):
             return get_list_component(result_sbom, remoteconfig["TRIVY"]["SBOM_FORMAT"])
 
         except subprocess.CalledProcessError as e:
-            logger.error(f"Error generating SBOM: {e}")
-            logger.error(f"Command stdout: {e.stdout}")
-            logger.error(f"Command stderr: {e.stderr}")
+            logger.error(f"Error generating SBOM: {e} \nCommand stdout: {e.stdout} \nCommand stderr: {e.stderr}")
         except Exception as e:
             logger.error(f"Unexpected error generating SBOM: {e}")
 

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/src/infrastructure/driven_adapters/trivy_tool/trivy_manager_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/src/infrastructure/driven_adapters/trivy_tool/trivy_manager_scan.py
@@ -49,8 +49,12 @@ class TrivyScan(ToolGateway):
 
             return result_file
 
-        except Exception as e:
+        except subprocess.CalledProcessError as e:
             logger.error(f"Error during image scan of {image_name}: {e}")
+            logger.error(f"Command stdout: {e.stdout}")
+            logger.error(f"Command stderr: {e.stderr}")
+        except Exception as e:
+            logger.error(f"Unexpected error during image scan of {image_name}: {e}")
 
     def _generate_sbom(self, prefix, image_name, remoteconfig, vuln_type, ignore_unfixed=False, is_compressed_file=False):
         result_sbom = f"{image_name.replace('/', '_')}_SBOM.json"
@@ -82,8 +86,12 @@ class TrivyScan(ToolGateway):
 
             return get_list_component(result_sbom, remoteconfig["TRIVY"]["SBOM_FORMAT"])
 
-        except Exception as e:
+        except subprocess.CalledProcessError as e:
             logger.error(f"Error generating SBOM: {e}")
+            logger.error(f"Command stdout: {e.stdout}")
+            logger.error(f"Command stderr: {e.stderr}")
+        except Exception as e:
+            logger.error(f"Unexpected error generating SBOM: {e}")
 
     def run_tool_container_sca(self, remoteconfig, secret_tool, token_engine_container, image_name, result_file, base_image, exclusions, generate_sbom, docker_address, is_compressed_file=False):
         trivy_version = remoteconfig["TRIVY"]["TRIVY_VERSION"]

--- a/tools/devsecops_engine_tools/engine_sca/engine_container/test/infrastructure/driven_adapters/trivy_tool/test_trivy_manager_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_container/test/infrastructure/driven_adapters/trivy_tool/test_trivy_manager_scan.py
@@ -31,7 +31,7 @@ def test_scan_image_exception(trivy_scan_instance):
 
         trivy_scan_instance.scan_image("prefix", "image_name", "result.json","base_image", "os,library")
 
-        mock_logger.assert_called_with("Error during image scan of image_name: custom error")
+        mock_logger.assert_called_with("Unexpected error during image scan of image_name: custom error")
 
 
 def test_run_tool_container_sca_success(trivy_scan_instance):
@@ -142,7 +142,7 @@ def test_generate_sbom_failure(mock_logger, mock_subprocess_run):
     # Llamar a la función y verificar que se lanza la excepción esperada
     trivy_scan._generate_sbom(prefix, image_name, remoteconfig, vuln_type)
 
-    mock_logger.error.assert_called_once_with("Error generating SBOM: Test exception")
+    mock_logger.error.assert_called_once_with("Unexpected error generating SBOM: Test exception")
 
 
 @patch('devsecops_engine_tools.engine_sca.engine_container.src.infrastructure.driven_adapters.trivy_tool.trivy_manager_scan.subprocess.run')


### PR DESCRIPTION
## Description

show logs in trivy failed executions

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
