### PR TITLE
fix: raise exception if trivy deps scan fail

### DIFF
--- a/tools/devsecops_engine_tools/engine_sca/engine_dependencies/src/infrastructure/driven_adapters/trivy_tool/trivy_manager_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_dependencies/src/infrastructure/driven_adapters/trivy_tool/trivy_manager_scan.py
@@ -105,3 +105,4 @@ class TrivyScanSBOM(ToolGateway):
 
         except Exception as e:
             logger.error(f"Error during SBOM scan of {sbom_path}: {e}")
+            raise

--- a/tools/devsecops_engine_tools/engine_sca/engine_dependencies/test/infrastructure/driven_adapters/trivy_tool/test_trivy_manager_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_dependencies/test/infrastructure/driven_adapters/trivy_tool/test_trivy_manager_scan.py
@@ -82,11 +82,11 @@ class TestTrivyScanSBOM(unittest.TestCase):
         
         mock_subprocess_run.side_effect = Exception(error_message)
         
-        # Act
-        result = self.trivy_scanner._scan_dependencies_sbom(command_prefix, sbom_path)
+        # Act & Assert
+        with self.assertRaises(Exception) as context:
+            self.trivy_scanner._scan_dependencies_sbom(command_prefix, sbom_path)
         
-        # Assert
-        self.assertIsNone(result)
+        self.assertEqual(str(context.exception), error_message)
         mock_logger.error.assert_called_once_with(f"Error during SBOM scan of {sbom_path}: {error_message}")
 
     @patch('devsecops_engine_tools.engine_sca.engine_dependencies.src.infrastructure.driven_adapters.trivy_tool.trivy_manager_scan.os.path.exists')


### PR DESCRIPTION
## Fix
raise exception if trivy deps scan fail

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
