### PR TITLE
fix(engine_function): sanitize ANSI escapes in Prisma severity parsing

### DIFF
--- a/tools/devsecops_engine_tools/engine_sca/engine_function/src/infrastructure/driven_adapters/prisma_cloud/prisma_cloud_manager_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_function/src/infrastructure/driven_adapters/prisma_cloud/prisma_cloud_manager_scan.py
@@ -13,6 +13,7 @@ from devsecops_engine_tools.engine_utilities.twistcli_utils.twistcli_utils impor
 
 
 logger = MyLogger.__call__(**settings.SETTING_LOGGER).get_logger()
+ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
 
 class PrismaCloudManagerScan:
@@ -165,10 +166,8 @@ class PrismaCloudManagerScan:
             } if match else {}
 
         def clean_text(text) -> str:
-            cleaned_text = text.replace('\x1b[0m', '')
-            cleaned_text = cleaned_text.replace('\x1b[91;1m', '')
-            cleaned_text = cleaned_text.replace('\x1b[33;1m','')
-            return cleaned_text
+            cleaned_text = ANSI_ESCAPE_RE.sub("", str(text))
+            return cleaned_text.strip()
 
         def extract_table() -> list:
             lines = stdout.splitlines()

--- a/tools/devsecops_engine_tools/engine_sca/engine_function/src/infrastructure/driven_adapters/prisma_cloud/prisma_deserialize_output.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_function/src/infrastructure/driven_adapters/prisma_cloud/prisma_deserialize_output.py
@@ -7,6 +7,9 @@ from devsecops_engine_tools.engine_core.src.domain.model.finding import (
 )
 from datetime import datetime
 from dataclasses import dataclass
+import re
+
+ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
 @dataclass
 class PrismaDeserealizator(DeseralizatorGateway):
@@ -29,6 +32,10 @@ class PrismaDeserealizator(DeseralizatorGateway):
         }
         vuls_data = function_scanned["results"][0]["vulnerabilities"]
 
+        def normalize_severity(value: str) -> str:
+            clean_value = ANSI_ESCAPE_RE.sub("", str(value or "")).strip().lower()
+            return SEVERITY_MAP.get(clean_value, "")
+                    
         if len(vuls_data) > 0:
             vulnerabilities = [
                 Finding(
@@ -38,7 +45,7 @@ class PrismaDeserealizator(DeseralizatorGateway):
                     + ":"
                     + vul.get("packageVersion", ""),
                     description=vul.get("description", "")[:150],
-                    severity=SEVERITY_MAP.get(vul.get("severity", ""), ""),
+                    severity=normalize_severity(vul.get("severity", "")),
                     identification_date=vul.get("discoveredDate", ""),
                     published_date_cve=vul.get("publishedDate", "").replace(
                         "Z", "+00:00"


### PR DESCRIPTION
## Description

This PR fixes an issue where ANSI escape/control sequences from Prisma/Twistcli output leaked into parsed vulnerability severity values (for example, `\x1b[31;1Mcritical`). As a result, severity normalization and downstream payload validation could fail in pipeline executions.

The fix adds robust ANSI sanitization during function-scan parsing and normalizes severity values before findings are built, ensuring valid outputs `critical/high/medium/low` are consistently produced.

### Fix

To fix in code/runtime
- Sanitize scanner text output before field extraction so terminal color/control bytes are removed.
- Normalize severity values with `strip + lower + mapping` before building findings.

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
