### PR TITLE
feat: Add CLI flag to enable license analyzer 

### DIFF
--- a/docs/Docusaurus/docs/modules/engine_core.md
+++ b/docs/Docusaurus/docs/modules/engine_core.md
@@ -107,7 +107,6 @@ Configuration of the driven adapters in the main layer and management of on/off 
         }
     },
     "LICENSE_ANALYZER": {
-        "ENABLED": true,
         "TOOL": "DEPENDENCY_TRACK",
         "DEPENDENCY_TRACK": {
             "HOST": "",
@@ -347,8 +346,7 @@ Configuration of the driven adapters in the main layer and management of on/off 
         - ROLE_ARN: ARN of the assumed role with permissions over this resource
         - REGION_NAME: AWS region name
 
-- **LICENSE_ANALYZER**: Configuration for the license analysis integration (beta). Uploads the generated SBOM to a license analyzer tool to inspect component licenses. Only runs if `SBOM_MANAGER.ENABLED` is `true` for the current branch.
-    - **ENABLED**: `true` or `false`. Enables or disables the license analyzer upload.
+- **LICENSE_ANALYZER**: Configuration for the license analysis integration (beta). Uploads the generated SBOM to a license analyzer tool to inspect component licenses. Activated via the `--use_license_analyzer true` CLI flag. Only runs if `SBOM_MANAGER.ENABLED` is `true` for the current branch.
     - **TOOL**: License analyzer adapter to use. Currently supported: `DEPENDENCY_TRACK`.
     - **DEPENDENCY_TRACK**
         - **HOST**: Base URL of the Dependency-Track server (e.g., `https://dtrack.example.com`).
@@ -356,7 +354,7 @@ Configuration of the driven adapters in the main layer and management of on/off 
         - **EXPORT_TASK_ID**: `true` or `false`. When enabled, the upload task token returned by Dependency-Track is exported as a pipeline variable, allowing downstream jobs to poll for analysis results.
         - **TASK_ID_VARIABLE_NAME**: Name of the pipeline variable where the task token will be stored (only used when `EXPORT_TASK_ID` is `true`).
 
-- **SBOM_MANAGER**: Configuration for SBOM generation. Requires `ENABLED: true` for `LICENSE_ANALYZER` to run. Additionally, `CDXGEN.FETCH_LICENSE` should be set to `true` to enrich the SBOM with license metadata before uploading to the license analyzer.
+- **SBOM_MANAGER**: Configuration for SBOM generation. Requires `ENABLED: true` and the `--use_license_analyzer true` CLI flag for the license analyzer to run. Additionally, `CDXGEN.FETCH_LICENSE` should be set to `true` to enrich the SBOM with license metadata before uploading to the license analyzer.
     - **SYFT**
         - **SYFT_VERSION**: Version of Syft to download and use. Example: `"1.17.0"`.
         - **OUTPUT_FORMAT**: Output format for the SBOM. Default: `"cyclonedx-json"`. Other options include `"spdx-json"`, `"syft-json"`, `"table"`.
@@ -365,7 +363,7 @@ Configuration of the driven adapters in the main layer and management of on/off 
         - **DEBUG_PIPELINES**: Array of pipeline names where Syft should run in verbose mode (`-v` flag). Useful for troubleshooting SBOM generation issues in specific pipelines. Example: `["pipeline_name1", "pipeline_name2"]`.
                 
     - **CDXGEN**
-        - **FETCH_LICENSE**: `true` or `false`. When enabled, cdxgen fetches license information for each component from public registries and includes it in the generated SBOM. Recommended when `LICENSE_ANALYZER` is enabled.
+        - **FETCH_LICENSE**: `true` or `false`. When enabled, cdxgen fetches license information for each component from public registries and includes it in the generated SBOM. Recommended when `--use_license_analyzer true` is used.
         - **INSTALL_DEPENDENCIES**: `true` or `false`. When enabled, cdxgen installs project dependencies before generating the SBOM, improving component coverage.
         - **OVERRIDE_REGISTRIES**: `true` or `false`. When enabled, the registry URLs defined in `REGISTRIES` are set as environment variables before cdxgen runs, redirecting dependency resolution to internal or private registries.
         - **REGISTRIES**: Map of environment variable names to registry URLs used when `OVERRIDE_REGISTRIES` is `true`.

--- a/example_remote_config_local/engine_core/ConfigTool.json
+++ b/example_remote_config_local/engine_core/ConfigTool.json
@@ -87,7 +87,6 @@
         }
     },
     "LICENSE_ANALYZER": {
-        "ENABLED": false,
         "TOOL": "DEPENDENCY_TRACK",
         "DEPENDENCY_TRACK": {
             "HOST": "",

--- a/tools/devsecops_engine_tools/engine_core/src/applications/runner_engine_core.py
+++ b/tools/devsecops_engine_tools/engine_core/src/applications/runner_engine_core.py
@@ -220,6 +220,14 @@ def get_inputs_from_cli(args):
         help="Token to execute license analyzer if is necessary. The expected value is the API key to connect with the license analyzer tool, for example, Dependency Track API key.",
     )
     parser.add_argument(
+        "--use_license_analyzer",
+        choices=["true", "false"],
+        type=str,
+        required=False,
+        default="false",
+        help="Enable or disable the license analyzer upload to a third-party tool. Only runs if SBOM_MANAGER is enabled for the current branch.",
+    )
+    parser.add_argument(
         "--xray_mode",
         choices=["scan", "audit","build-scan"],
         required=False,
@@ -292,6 +300,7 @@ def get_inputs_from_cli(args):
         "token_external_checks": args.token_external_checks,
         "token_engine_code": args.token_engine_code,
         "token_license_analyzer": args.token_license_analyzer,
+        "use_license_analyzer": args.use_license_analyzer,
         "xray_mode": args.xray_mode,
         "image_to_scan": args.image_to_scan,
         "dast_file_path": args.dast_file_path,

--- a/tools/devsecops_engine_tools/engine_core/test/applications/test_runner_engine_core.py
+++ b/tools/devsecops_engine_tools/engine_core/test/applications/test_runner_engine_core.py
@@ -116,6 +116,7 @@ def test_get_inputs_from_cli(mock_parse_args):
     mock_args.context = "false"
     mock_args.token_engine_code=None
     mock_args.token_license_analyzer = None
+    mock_args.use_license_analyzer = "false"
     mock_args.docker_address = "unix:///var/run/docker.sock"
     # Mock the parse_args method
     mock_parse_args.return_value = mock_args
@@ -148,6 +149,7 @@ def test_get_inputs_from_cli(mock_parse_args):
         "context": "false",
         "token_engine_code": None,
         "token_license_analyzer": None,
+        "use_license_analyzer": "false",
         "docker_address": "unix:///var/run/docker.sock",
     }
 

--- a/tools/devsecops_engine_tools/engine_sca/engine_dependencies/src/infrastructure/entry_points/entry_point_tool.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_dependencies/src/infrastructure/entry_points/entry_point_tool.py
@@ -98,7 +98,7 @@ def init_engine_dependencies(
                     pipeline_name
                 )
 
-                if config_tool["LICENSE_ANALYZER"]["ENABLED"]:
+                if dict_args.get("use_license_analyzer") == "true":
                     token_license_analyzer = secret_tool.get(config_license[license_tool]["API_KEY_SECRET_KEY"]) if secret_tool else dict_args.get("token_license_analyzer")
                     
                     if not token_license_analyzer:

--- a/tools/devsecops_engine_tools/engine_sca/engine_dependencies/test/infrastructure/entry_points/test_entry_point_tool.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_dependencies/test/infrastructure/entry_points/test_entry_point_tool.py
@@ -19,7 +19,7 @@ def test_init_engine_dependencies():
         tool = {
             "ENGINE_DEPENDENCIES": {"TOOL": "tool"},
             "SBOM_MANAGER": {"ENABLED": True, "BRANCH_FILTER": ["trunk"]},
-            "LICENSE_ANALYZER": {"ENABLED": False, "TOOL": "dep_track"},
+            "LICENSE_ANALYZER": {"TOOL": "dep_track"},
         }
         mock_handle_remote_config_patterns.process_handle_working_directory.return_value = (
             "working_dir"
@@ -68,7 +68,7 @@ def test_init_engine_dependencies_success(mock_exists, mock_dependencies_scan, m
     config_tool = {
         "SBOM_MANAGER": {"ENABLED": True, "BRANCH_FILTER": ["main"]},
         "ENGINE_DEPENDENCIES": {"TOOL": "tool"},
-        "LICENSE_ANALYZER": {"ENABLED": False, "TOOL": "dep_track"},
+        "LICENSE_ANALYZER": {"TOOL": "dep_track"},
     }
 
     # Llamar a la función
@@ -104,7 +104,7 @@ def test_init_engine_dependencies_skip_tool(mock_set_input_core, mock_handle_rem
     config_tool = {
         "SBOM_MANAGER": {"ENABLED": False, "BRANCH_FILTER": []},
         "ENGINE_DEPENDENCIES": {"TOOL": "tool"},
-        "LICENSE_ANALYZER": {"ENABLED": False, "TOOL": "dep_track"},
+        "LICENSE_ANALYZER": {"TOOL": "dep_track"},
     }
     dict_args = {"remote_config_repo": "repo", "folder_path": None, "remote_config_branch": ""}
 
@@ -137,7 +137,7 @@ def test_init_engine_dependencies_path_not_exists(mock_logger, mock_exists, mock
     config_tool = {
         "SBOM_MANAGER": {"ENABLED": False, "BRANCH_FILTER": []},
         "ENGINE_DEPENDENCIES": {"TOOL": "tool"},
-        "LICENSE_ANALYZER": {"ENABLED": False, "TOOL": "dep_track"},
+        "LICENSE_ANALYZER": {"TOOL": "dep_track"},
     }
     dict_args = {"remote_config_repo": "repo", "folder_path": "nonexistent_path", "remote_config_branch": ""}
 
@@ -157,7 +157,7 @@ def test_init_engine_dependencies_path_not_exists(mock_logger, mock_exists, mock
 @patch('devsecops_engine_tools.engine_sca.engine_dependencies.src.infrastructure.entry_points.entry_point_tool.os.path.exists')
 @patch('devsecops_engine_tools.engine_sca.engine_dependencies.src.infrastructure.entry_points.entry_point_tool.logger')
 def test_init_engine_dependencies_license_no_token(mock_logger, mock_exists, mock_dependencies_scan, mock_set_input_core, mock_handle_remote_config_patterns):
-    """Covers LICENSE_ANALYZER.ENABLED=True but no token → logger.error."""
+    """Covers --use_license_analyzer=true but no token → logger.error."""
     mock_exists.return_value = True
     mock_handle_remote_config_patterns.return_value.skip_from_exclusion.return_value = False
     mock_handle_remote_config_patterns.return_value.ignore_analysis_pattern.return_value = True
@@ -175,7 +175,6 @@ def test_init_engine_dependencies_license_no_token(mock_logger, mock_exists, moc
         "SBOM_MANAGER": {"ENABLED": True, "BRANCH_FILTER": ["main"]},
         "ENGINE_DEPENDENCIES": {"TOOL": "tool"},
         "LICENSE_ANALYZER": {
-            "ENABLED": True,
             "TOOL": "dep_track",
             "dep_track": {
                 "API_KEY_SECRET_KEY": "api_key_secret",
@@ -184,7 +183,7 @@ def test_init_engine_dependencies_license_no_token(mock_logger, mock_exists, moc
             },
         },
     }
-    dict_args = {"remote_config_repo": "repo", "folder_path": "path", "remote_config_branch": ""}
+    dict_args = {"remote_config_repo": "repo", "folder_path": "path", "remote_config_branch": "", "use_license_analyzer": "true"}
 
     # secret_tool=None and no token_license_analyzer in dict_args → token is None
     init_engine_dependencies(
@@ -222,7 +221,6 @@ def test_init_engine_dependencies_license_upload_with_export_task_id(mock_logger
         "SBOM_MANAGER": {"ENABLED": True, "BRANCH_FILTER": ["main"]},
         "ENGINE_DEPENDENCIES": {"TOOL": "tool"},
         "LICENSE_ANALYZER": {
-            "ENABLED": True,
             "TOOL": "dep_track",
             "dep_track": {
                 "API_KEY_SECRET_KEY": "api_key_secret",
@@ -232,7 +230,7 @@ def test_init_engine_dependencies_license_upload_with_export_task_id(mock_logger
             },
         },
     }
-    dict_args = {"remote_config_repo": "repo", "folder_path": "path", "remote_config_branch": ""}
+    dict_args = {"remote_config_repo": "repo", "folder_path": "path", "remote_config_branch": "", "use_license_analyzer": "true"}
 
     secret_tool = MagicMock()
     secret_tool.get_secret.return_value = "valid_token"
@@ -273,7 +271,6 @@ def test_init_engine_dependencies_license_upload_without_task_id_does_not_export
         "SBOM_MANAGER": {"ENABLED": True, "BRANCH_FILTER": ["main"]},
         "ENGINE_DEPENDENCIES": {"TOOL": "tool"},
         "LICENSE_ANALYZER": {
-            "ENABLED": True,
             "TOOL": "dep_track",
             "dep_track": {
                 "API_KEY_SECRET_KEY": "api_key_secret",
@@ -283,7 +280,7 @@ def test_init_engine_dependencies_license_upload_without_task_id_does_not_export
             },
         },
     }
-    dict_args = {"remote_config_repo": "repo", "folder_path": "path", "remote_config_branch": ""}
+    dict_args = {"remote_config_repo": "repo", "folder_path": "path", "remote_config_branch": "", "use_license_analyzer": "true"}
 
     secret_tool = MagicMock()
     secret_tool.get.return_value = "valid_token"


### PR DESCRIPTION
## Description

#631 Introduce the --use_license_analyzer argument to explicitly enable the license analyzer flow, replacing the previous activation through LICENSE_ANALYZER.ENABLED in ConfigTool.json. This change also updates the related documentation and tests.
