### PR TITLE
refactor: hardened trivy download with checksum verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,99 +1,171 @@
-#Proof Archives
-_AW1234
-_nu1234
-DevSecOps_Remote_Config
-*.jar
+# =============================================================================
+# Python
+# =============================================================================
+# Virtual environments
+.venv*/
+.venv_win/
+_venv/
 
-# Virtual Enviroment python
-.venv*
-.venv_win
-*.vscode
-.pytest*
-*pycache*
-*_pycache_*
-.*DS_Store
+# Byte-compiled / cached files
+*.pyc
+__pycache__/
+*_pycache_*/
+*.pyo
+
+# Distributions
+*.egg-info/
+*.egg
+dist/
+build/
+tools/build/
+build/lib/
+
+# Package managers
 Pipfile
+Pipfile.lock
+poetry.lock
 
-#Distribucioes de lib
-**dist**
-**.egg-info/
-*.pyc
-**_pycache_**
-**tools/build/**
-**build/lib**
+# =============================================================================
+# IDE & Editors
+# =============================================================================
+.vscode/
+*.vscode
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
 
-#Ignorar cualquir archivo TXT
-scanned_images.txt
-*.pyc
-data
-
-#Archivos de Pruebas
-.env
+# =============================================================================
+# Testing & Coverage
+# =============================================================================
+.pytest_cache/
+htmlcov/
+.coverage
+coverage.xml
+.nyc_output/
+coverage/
 test-output.xml
 report.html
 out_report.xml
-htmlcov
-.coverage
-coverage.xml
-prueba.py
-main.py
-common_devsecops_lib/sheckov_scan.json
+out/
+pytest.ini
+
+# Test artifacts
 _core_test*
 results*.json
+test_file/
+
+# =============================================================================
+# Build & Compilation Artifacts
+# =============================================================================
+target/
+node_modules/
+*.jar
+*.js
+*.map
+*.vsix
+*-lock.json
+
+# =============================================================================
+# Security Scanning Tools & Artifacts
+# =============================================================================
+# Trivy
+trivy
+trivy_*.tar.gz
+trivy_*.zip
+*_SBOM.json
+*scan_result.json
+
+# Checkov
+checkov
+checkov.exe
+scanned_images.txt
 RULES_DOCKERcheckov_config.yaml
 RULES_K8Scheckov_config.yaml
 RULES_CLOUDFORMATIONcheckov_config.yaml
 RULES_OPENAPIcheckov_config.yaml
 RULES_TERRAFORMcheckov_config.yaml
 RULES_SERVERLESScheckov_config.yaml
-log/
-twistcli
-trivy
-trivy_*.zip
-*scan_result.json
+common_devsecops_lib/sheckov_scan.json
+
+# KICS
+kics/
+kics-devsecops/
+kics_*.zip
+kics_assets/
+
+# JFrog Xray
 jf
 jf.exe
-target
-dependencies_to_scan
-node_modules
-DevSecOps_Remote_Config
-*.js
-*.map
-kics/
-kics_assets/
-assets_compressed.zip
-kics_*.zip
-kubescape-macos-latest
-*.tar.gz
-*.zip
-*_SBOM.json
+
+# Syft
 syft
+
+# Copa
+copa
+copa.exe
+
+# cdxgen
+cdxgen-*
+
+# Gitleaks
 gitleaks_aux_report_*.json
 gitleaks_report.json
-result_dast_scan.json
-test_file/*
-pytest.ini
-kics-devsecops/
+
+# OWASP Dependency-Check
 dependency-check-report*
-*.vsix
-**-lock.json
 
-# Extensions
-out
-.nyc_output/
-coverage/
-.vscode-test
+# Prisma/Twistlock
+twistcli
 
-# Binarios
-checkov
-checkov.exe
-build/**
-copa
-cdxgen-*
-build/** 
-cdxgen-*
-copa
+# Kubescape
+kubescape-macos-latest
 
-# Doc
-.docusaurus
-docs/Docusaurus/build/**
+# =============================================================================
+# Test Files & Data
+# =============================================================================
+.env
+.env*local
+.envdetlocal
+.envdetlocalazure
+data/
+prueba.py
+main.py
+dependencies_to_scan/
+
+# DAST
+result_dast_scan.json
+
+# =============================================================================
+# Archives & Bundles
+# =============================================================================
+assets_compressed.zip
+_AW1234
+_nu1234
+DevSecOps_Remote_Config/
+
+# =============================================================================
+# Documentation Builds
+# =============================================================================
+.docusaurus/
+docs/Docusaurus/build/
+
+# =============================================================================
+# Logs
+# =============================================================================
+log/
+*.log
+
+# =============================================================================
+# Kiuwan Agent (generated files)
+# =============================================================================
+tools/agent.version
+tools/bin/
+tools/conf/
+tools/development/
+tools/doc/
+tools/kiuwan.cmd
+tools/kiuwan.sh
+tools/lib.custom/
+tools/readme.txt

--- a/docs/Docusaurus/docs/modules/engine_sca/engine_container.md
+++ b/docs/Docusaurus/docs/modules/engine_sca/engine_container.md
@@ -25,7 +25,7 @@ Main configuration file that defines scanning behavior, tool versions, and secur
     "SCAN_RETRY_DELAY_TAR_SECONDS": 0
   },
   "TRIVY": {
-    "TRIVY_VERSION": "0.62.1",
+    "TRIVY_VERSION": "0.69.3",
     "SBOM_FORMAT": "cyclonedx",
     "VULN_TYPE": "all",
     "IGNORE_UNFIXED": false
@@ -129,7 +129,7 @@ Main configuration file that defines scanning behavior, tool versions, and secur
 - **SCAN_RETRY_DELAY_TAR_SECONDS**: Delay (seconds) between retries for TAR image scans
 
 ##### Trivy Configuration
-- **TRIVY_VERSION**: Trivy scanner version to use (e.g., `"0.62.1"`)
+- **TRIVY_VERSION**: Trivy scanner version to use (e.g., `"0.69.3"`)
 - **SBOM_FORMAT**: SBOM output format (`"cyclonedx"` for CycloneDX format)
 - **VULN_TYPE**: Types of vulnerabilities to scan (`"all"` for comprehensive scanning)
 - **IGNORE_UNFIXED**: Boolean flag to ignore vulnerabilities without available fixes

--- a/docs/Docusaurus/docs/modules/engine_sca/engine_dependencies.md
+++ b/docs/Docusaurus/docs/modules/engine_sca/engine_dependencies.md
@@ -50,7 +50,7 @@ Main configuration file that defines scanning behavior, tool versions, and secur
     "VULNERABILITY_CONFIDENCE": ["highest"]
   },
   "TRIVY": {
-    "CLI_VERSION": "0.65.0",
+    "TRIVY_VERSION": "0.69.3",
     "PRINT_SBOM": ["pipeline_name_1"]
   }
 }
@@ -74,7 +74,8 @@ Main configuration file that defines scanning behavior, tool versions, and secur
 - **VULNERABILITY_CONFIDENCE**: Array of confidence levels for vulnerability detection (e.g., `["highest"]`)
 
 ##### Trivy Tool Configuration
-- **CLI_VERSION**: Trivy scanner version to use (e.g., `"0.65.0"`)
+- **TRIVY_VERSION**: Trivy scanner version to use (e.g., `"0.69.3"`)
+  - **Note**: `CLI_VERSION` is deprecated but still supported for backward compatibility
 
 ##### General Configuration
 - **IGNORE_ANALYSIS_PATTERN**: Regex pattern to exclude directories/files from analysis (e.g., `"(.*_test)"` ignores test directories)

--- a/example_remote_config_local/engine_sca/engine_container/ConfigTool.json
+++ b/example_remote_config_local/engine_sca/engine_container/ConfigTool.json
@@ -10,7 +10,7 @@
         "SCAN_RETRY_DELAY_TAR_SECONDS": 0
     },
     "TRIVY": {
-        "TRIVY_VERSION": "0.62.1",
+        "TRIVY_VERSION": "0.69.3",
         "SBOM_FORMAT": "cyclonedx",
         "VULN_TYPE": "all",
         "IGNORE_UNFIXED": false
@@ -37,7 +37,7 @@
     "VALIDATE_BASE_IMAGE_DATE": {
         "ENABLED": false,
         "REFERENCE_IMAGE_DATE": "20250206"
-        
+
     },
     "BLACK_LIST_BASE_IMAGE": {
         "ENABLED": false,

--- a/example_remote_config_local/engine_sca/engine_dependencies/ConfigTool.json
+++ b/example_remote_config_local/engine_sca/engine_dependencies/ConfigTool.json
@@ -35,7 +35,8 @@
         "VULNERABILITY_CONFIDENCE" : ["highest"]
     },
     "TRIVY": {
-        "CLI_VERSION": "0.65.0",
-        "PRINT_SBOM": ["pipeline_name_1"]
+        "TRIVY_VERSION": "0.69.3",
+        "PRINT_SBOM": ["pipeline_name_1"],
+        "_NOTE": "TRIVY_VERSION is the standardized key. CLI_VERSION is deprecated but still supported for backward compatibility."
     }
 }

--- a/tools/devsecops_engine_tools/engine_sca/engine_dependencies/src/infrastructure/driven_adapters/trivy_tool/trivy_manager_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_dependencies/src/infrastructure/driven_adapters/trivy_tool/trivy_manager_scan.py
@@ -30,7 +30,17 @@ class TrivyScanSBOM(ToolGateway):
         token_engine_dependencies,
         **kwargs,
     ):
-        trivy_version = remote_config["TRIVY"]["CLI_VERSION"]
+        # Support both TRIVY_VERSION (standardized) and CLI_VERSION (legacy)
+        trivy_config = remote_config.get("TRIVY", {})
+        trivy_version = trivy_config.get("TRIVY_VERSION") or trivy_config.get("CLI_VERSION")
+
+        if not trivy_version:
+            logger.error(
+                "Trivy version not found in configuration. "
+                "Please set either TRIVY_VERSION or CLI_VERSION in the TRIVY config block."
+            )
+            return None
+
         command_prefix = TrivyManagerScanUtils().identify_os_and_install(trivy_version)
         sbom = f"{pipeline_name}_SBOM.json"
 
@@ -41,17 +51,17 @@ class TrivyScanSBOM(ToolGateway):
             raise FileNotFoundError("SBOM file not found, enable SBOM generation to scan with Trivy.")
 
         if pipeline_name in remote_config["TRIVY"].get("PRINT_SBOM", []):
-            with open(sbom, "r") as file: 
+            with open(sbom, "r") as file:
                 print("SBOM content:")
                 print(json.dumps(json.load(file), indent=4))
-            
+
         dependencies_scanned = self._scan_dependencies_sbom(command_prefix, sbom)
 
         return dependencies_scanned
 
     def get_dependencies_context_from_results(
-            self, 
-            path_file_results, 
+            self,
+            path_file_results,
             remote_config
     ) -> List[ContextDependencies]:
         dependencies_container_list = []

--- a/tools/devsecops_engine_tools/engine_sca/engine_dependencies/test/infrastructure/driven_adapters/trivy_tool/test_trivy_manager_scan.py
+++ b/tools/devsecops_engine_tools/engine_sca/engine_dependencies/test/infrastructure/driven_adapters/trivy_tool/test_trivy_manager_scan.py
@@ -11,14 +11,14 @@ class TestTrivyScanSBOM(unittest.TestCase):
         self.trivy_scanner = TrivyScanSBOM()
         self.sample_sbom_path = "/tmp/test_pipeline_SBOM.json"
         self.sample_result_path = "/tmp/test_pipeline_SBOM_scan_result.json"
-        
+
         # Mock data for tests
         self.mock_remote_config = {
             "TRIVY": {
-                "CLI_VERSION": "0.45.0"
+                "TRIVY_VERSION": "0.45.0"
             }
         }
-        
+
         self.mock_trivy_result = {
             "Results": [
                 {
@@ -54,13 +54,13 @@ class TestTrivyScanSBOM(unittest.TestCase):
         command_prefix = "/usr/bin/trivy"
         sbom_path = self.sample_sbom_path
         expected_result_file = self.sample_result_path
-        
+
         mock_subprocess_run.return_value = Mock(returncode=0)
-        
+
         # Act
         with patch('builtins.print') as mock_print:
             result = self.trivy_scanner._scan_dependencies_sbom(command_prefix, sbom_path)
-        
+
         # Assert
         self.assertEqual(result, expected_result_file)
         mock_subprocess_run.assert_called_once_with(
@@ -79,13 +79,13 @@ class TestTrivyScanSBOM(unittest.TestCase):
         command_prefix = "/usr/bin/trivy"
         sbom_path = self.sample_sbom_path
         error_message = "Command failed"
-        
+
         mock_subprocess_run.side_effect = Exception(error_message)
-        
+
         # Act & Assert
         with self.assertRaises(Exception) as context:
             self.trivy_scanner._scan_dependencies_sbom(command_prefix, sbom_path)
-        
+
         self.assertEqual(str(context.exception), error_message)
         mock_logger.error.assert_called_once_with(f"Error during SBOM scan of {sbom_path}: {error_message}")
 
@@ -95,16 +95,16 @@ class TestTrivyScanSBOM(unittest.TestCase):
         # Arrange
         mock_identify_os.return_value = "/usr/bin/trivy"
         mock_exists.return_value = True
-        
+
         dict_args = {}
         exclusion = []
         pipeline_name = "test_pipeline"
         to_scan = []
         secret_tool = None
         token_engine_dependencies = "test_token"
-        
+
         expected_result_file = f"{pipeline_name}_SBOM_scan_result.json"
-        
+
         # Act
         with patch.object(self.trivy_scanner, '_scan_dependencies_sbom', return_value=expected_result_file) as mock_scan:
             result = self.trivy_scanner.run_tool_dependencies_sca(
@@ -116,7 +116,7 @@ class TestTrivyScanSBOM(unittest.TestCase):
                 secret_tool,
                 token_engine_dependencies
             )
-        
+
         # Assert
         self.assertEqual(result, expected_result_file)
         mock_identify_os.assert_called_once_with("0.45.0")
@@ -127,14 +127,14 @@ class TestTrivyScanSBOM(unittest.TestCase):
     def test_run_tool_dependencies_sca_no_command_prefix(self, mock_identify_os, mock_exists):
         # Arrange
         mock_identify_os.return_value = None
-        
+
         dict_args = {}
         exclusion = []
         pipeline_name = "test_pipeline"
         to_scan = []
         secret_tool = None
         token_engine_dependencies = "test_token"
-        
+
         # Act
         result = self.trivy_scanner.run_tool_dependencies_sca(
             self.mock_remote_config,
@@ -145,7 +145,7 @@ class TestTrivyScanSBOM(unittest.TestCase):
             secret_tool,
             token_engine_dependencies
         )
-        
+
         # Assert
         self.assertIsNone(result)
 
@@ -155,14 +155,14 @@ class TestTrivyScanSBOM(unittest.TestCase):
         # Arrange
         mock_identify_os.return_value = "/usr/bin/trivy"
         mock_exists.return_value = False
-        
+
         dict_args = {}
         exclusion = []
         pipeline_name = "test_pipeline"
         to_scan = []
         secret_tool = None
         token_engine_dependencies = "test_token"
-        
+
         # Act & Assert
         with self.assertRaises(FileNotFoundError) as context:
             self.trivy_scanner.run_tool_dependencies_sca(
@@ -174,25 +174,25 @@ class TestTrivyScanSBOM(unittest.TestCase):
                 secret_tool,
                 token_engine_dependencies
             )
-        
+
         self.assertEqual(str(context.exception), "SBOM file not found, enable SBOM generation to scan with Trivy.")
 
     def test_get_dependencies_context_from_results_success(self):
         # Arrange
         mock_file_content = json.dumps(self.mock_trivy_result).encode()
         expected_contexts_count = 2
-        
+
         # Act
         with patch('builtins.open', mock_open(read_data=mock_file_content)):
             result = self.trivy_scanner.get_dependencies_context_from_results(
                 self.sample_result_path,
                 self.mock_remote_config
             )
-        
+
         # Assert - verificar que retorna una lista con el número correcto de contextos
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), expected_contexts_count)
-        
+
         # Verificar el contenido de los contextos
         self.assertEqual(result[0].cve_id, ["CVE-2021-12345"])
         self.assertEqual(result[0].severity, "high")
@@ -202,18 +202,18 @@ class TestTrivyScanSBOM(unittest.TestCase):
     def test_get_dependencies_context_from_results_with_context_creation(self):
         # Arrange
         mock_file_content = json.dumps(self.mock_trivy_result).encode()
-        
+
         # Act
         with patch('builtins.open', mock_open(read_data=mock_file_content)):
             result = self.trivy_scanner.get_dependencies_context_from_results(
                 self.sample_result_path,
                 self.mock_remote_config
             )
-        
+
         # Assert - verificar el contenido de la lista retornada
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 2)
-        
+
         # Verificar el primer contexto
         first_context = result[0]
         self.assertEqual(first_context.cve_id, ["CVE-2021-12345"])
@@ -224,7 +224,7 @@ class TestTrivyScanSBOM(unittest.TestCase):
         self.assertEqual(first_context.fixed_version, ["1.0.1", "1.0.2"])
         self.assertEqual(first_context.description, "Test vulnerability descriptionwith newlines")
         self.assertEqual(first_context.source_tool, "Trivy")
-        
+
         # Verificar el segundo contexto
         second_context = result[1]
         self.assertEqual(second_context.cve_id, ["CVE-2021-67890"])
@@ -235,14 +235,14 @@ class TestTrivyScanSBOM(unittest.TestCase):
         # Arrange
         empty_result = {"Results": []}
         mock_file_content = json.dumps(empty_result).encode()
-        
+
         # Act
         with patch('builtins.open', mock_open(read_data=mock_file_content)):
             result = self.trivy_scanner.get_dependencies_context_from_results(
                 self.sample_result_path,
                 self.mock_remote_config
             )
-        
+
         # Assert
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 0)
@@ -251,14 +251,14 @@ class TestTrivyScanSBOM(unittest.TestCase):
         # Arrange
         result_without_vulns = {"Results": [{}]}
         mock_file_content = json.dumps(result_without_vulns).encode()
-        
+
         # Act
         with patch('builtins.open', mock_open(read_data=mock_file_content)):
             result = self.trivy_scanner.get_dependencies_context_from_results(
                 self.sample_result_path,
                 self.mock_remote_config
             )
-        
+
         # Assert
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 0)
@@ -280,18 +280,18 @@ class TestTrivyScanSBOM(unittest.TestCase):
             ]
         }
         mock_file_content = json.dumps(result_with_missing_fields).encode()
-        
+
         # Act
         with patch('builtins.open', mock_open(read_data=mock_file_content)):
             result = self.trivy_scanner.get_dependencies_context_from_results(
                 self.sample_result_path,
                 self.mock_remote_config
             )
-        
+
         # Assert
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
-        
+
         context = result[0]
         self.assertEqual(context.cve_id, ["CVE-2021-99999"])
         self.assertEqual(context.severity, "low")
@@ -301,3 +301,78 @@ class TestTrivyScanSBOM(unittest.TestCase):
         self.assertEqual(context.fixed_version, ["unknown"])
         self.assertEqual(context.description, "unknown")
         self.assertEqual(context.references, "unknown")
+
+    @patch('devsecops_engine_tools.engine_sca.engine_dependencies.src.infrastructure.driven_adapters.trivy_tool.trivy_manager_scan.os.path.exists')
+    @patch('devsecops_engine_tools.engine_utilities.trivy_utils.infrastructure.driven_adapters.trivy_manager_scan_utils.TrivyManagerScanUtils.identify_os_and_install')
+    def test_run_tool_dependencies_sca_backward_compat_cli_version(self, mock_identify_os, mock_exists):
+        """Test backward compatibility: CLI_VERSION should still work"""
+        # Arrange - using CLI_VERSION instead of TRIVY_VERSION
+        legacy_config = {
+            "TRIVY": {
+                "CLI_VERSION": "0.50.0"
+            }
+        }
+        mock_identify_os.return_value = "/usr/bin/trivy"
+        mock_exists.return_value = True
+
+        dict_args = {}
+        exclusion = []
+        pipeline_name = "test_pipeline"
+        to_scan = []
+        secret_tool = None
+        token_engine_dependencies = "test_token"
+
+        expected_result_file = f"{pipeline_name}_SBOM_scan_result.json"
+
+        # Act
+        with patch.object(self.trivy_scanner, '_scan_dependencies_sbom', return_value=expected_result_file) as mock_scan:
+            result = self.trivy_scanner.run_tool_dependencies_sca(
+                legacy_config,
+                dict_args,
+                exclusion,
+                pipeline_name,
+                to_scan,
+                secret_tool,
+                token_engine_dependencies
+            )
+
+        # Assert - should use CLI_VERSION value
+        self.assertEqual(result, expected_result_file)
+        mock_identify_os.assert_called_once_with("0.50.0")
+        mock_scan.assert_called_once_with("/usr/bin/trivy", f"{pipeline_name}_SBOM.json")
+
+    @patch('devsecops_engine_tools.engine_sca.engine_dependencies.src.infrastructure.driven_adapters.trivy_tool.trivy_manager_scan.os.path.exists')
+    @patch('devsecops_engine_tools.engine_utilities.trivy_utils.infrastructure.driven_adapters.trivy_manager_scan_utils.TrivyManagerScanUtils.identify_os_and_install')
+    @patch('devsecops_engine_tools.engine_sca.engine_dependencies.src.infrastructure.driven_adapters.trivy_tool.trivy_manager_scan.logger')
+    def test_run_tool_dependencies_sca_no_version(self, mock_logger, mock_identify_os, mock_exists):
+        """Test error when no version key is present"""
+        # Arrange - config with neither TRIVY_VERSION nor CLI_VERSION
+        bad_config = {
+            "TRIVY": {
+                "PRINT_SBOM": ["pipeline_name_1"]
+            }
+        }
+        mock_exists.return_value = True
+
+        dict_args = {}
+        exclusion = []
+        pipeline_name = "test_pipeline"
+        to_scan = []
+        secret_tool = None
+        token_engine_dependencies = "test_token"
+
+        # Act
+        result = self.trivy_scanner.run_tool_dependencies_sca(
+            bad_config,
+            dict_args,
+            exclusion,
+            pipeline_name,
+            to_scan,
+            secret_tool,
+            token_engine_dependencies
+        )
+
+        # Assert - should return None and log error
+        self.assertIsNone(result)
+        mock_logger.error.assert_called_once()
+        self.assertIn("Trivy version not found", mock_logger.error.call_args[0][0])

--- a/tools/devsecops_engine_tools/engine_utilities/test/trivy_utils/infrastructure/test_trivy_manager_scan_utils.py
+++ b/tools/devsecops_engine_tools/engine_utilities/test/trivy_utils/infrastructure/test_trivy_manager_scan_utils.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 from unittest.mock import patch, MagicMock, Mock
 from devsecops_engine_tools.engine_utilities.trivy_utils.infrastructure.driven_adapters.trivy_manager_scan_utils import TrivyManagerScanUtils
 
@@ -22,14 +23,15 @@ def test_download_tool_success(trivy_utils_instance):
 
 def test_download_tool_exception(trivy_utils_instance):
     """Test download_tool exception handling in TrivyManagerScanUtils"""
-    with patch("requests.get") as mock_request, patch(
-            "devsecops_engine_tools.engine_utilities.trivy_utils.infrastructure.driven_adapters.trivy_manager_scan_utils.logger.error"
-        ) as mock_logger:
+    with patch("requests.get") as mock_request:
         mock_request.side_effect = Exception("custom error")
 
-        trivy_utils_instance._download_tool("file", "url")
+        # The new implementation re-raises exceptions, so we expect it to propagate
+        with pytest.raises(Exception) as exc_info:
+            trivy_utils_instance._download_tool("file", "url")
 
-        mock_logger.assert_called_with("Error downloading trivy: custom error")
+        assert "custom error" in str(exc_info.value)
+        mock_request.assert_called_once()
 
 
 def test_install_tool_success(trivy_utils_instance):
@@ -99,9 +101,9 @@ def test_identify_os_and_install_linux(trivy_utils_instance):
         mock_arch.return_value = ("64bit", "")
         mock_install.return_value = "./trivy"
         version = "1.2.3"
-        
+
         result = trivy_utils_instance.identify_os_and_install(version)
-        
+
         expected_file = f"trivy_{version}_Linux-64bit.tar.gz"
         expected_url = f"https://github.com/aquasecurity/trivy/releases/download/v{version}/{expected_file}"
         mock_install.assert_called_with(expected_file, expected_url, "trivy")
@@ -117,9 +119,9 @@ def test_identify_os_and_install_linux_arm64(trivy_utils_instance):
         mock_machine.return_value = "aarch64"
         mock_install.return_value = "./trivy"
         version = "1.2.3"
-        
+
         result = trivy_utils_instance.identify_os_and_install(version)
-        
+
         expected_file = f"trivy_{version}_Linux-ARM64.tar.gz"
         expected_url = f"https://github.com/aquasecurity/trivy/releases/download/v{version}/{expected_file}"
         mock_install.assert_called_with(expected_file, expected_url, "trivy")
@@ -136,9 +138,9 @@ def test_identify_os_and_install_darwin(trivy_utils_instance):
         mock_arch.return_value = ("64bit", "")
         mock_install.return_value = "./trivy"
         version = "1.2.3"
-        
+
         result = trivy_utils_instance.identify_os_and_install(version)
-        
+
         expected_file = f"trivy_{version}_macOS-64bit.tar.gz"
         expected_url = f"https://github.com/aquasecurity/trivy/releases/download/v{version}/{expected_file}"
         mock_install.assert_called_with(expected_file, expected_url, "trivy")
@@ -154,9 +156,9 @@ def test_identify_os_and_install_darwin_arm64(trivy_utils_instance):
         mock_machine.return_value = "arm64"
         mock_install.return_value = "./trivy"
         version = "1.2.3"
-        
+
         result = trivy_utils_instance.identify_os_and_install(version)
-        
+
         expected_file = f"trivy_{version}_macOS-ARM64.tar.gz"
         expected_url = f"https://github.com/aquasecurity/trivy/releases/download/v{version}/{expected_file}"
         mock_install.assert_called_with(expected_file, expected_url, "trivy")
@@ -171,9 +173,9 @@ def test_identify_os_and_install_windows(trivy_utils_instance):
         mock_arch.return_value = ("64bit", "")
         mock_install.return_value = "./trivy.exe"
         version = "1.2.3"
-        
+
         result = trivy_utils_instance.identify_os_and_install(version)
-        
+
         expected_file = f"trivy_{version}_windows-64bit.zip"
         expected_url = f"https://github.com/aquasecurity/trivy/releases/download/v{version}/{expected_file}"
         mock_install.assert_called_with(expected_file, expected_url, "trivy.exe")
@@ -187,8 +189,115 @@ def test_identify_os_and_install_unsupported(trivy_utils_instance):
     ) as mock_logger:
         mock_platform.return_value = "UnsupportedOS"
         version = "1.2.3"
-        
+
         result = trivy_utils_instance.identify_os_and_install(version)
-        
+
         mock_logger.assert_called_with("UnsupportedOS is not supported.")
         assert result is None
+
+
+def test_identify_os_and_install_blocked_version(trivy_utils_instance):
+    """Test identify_os_and_install blocks compromised versions (CVE-2026-33634)"""
+    with patch("devsecops_engine_tools.engine_utilities.trivy_utils.infrastructure.driven_adapters.trivy_manager_scan_utils.logger.error") as mock_logger:
+        # Try to install a compromised version
+        result = trivy_utils_instance.identify_os_and_install("0.69.4")
+
+        # Should block the installation
+        assert result is None
+        mock_logger.assert_called_once()
+        assert "CVE-2026-33634" in mock_logger.call_args[0][0]
+        assert "compromised" in mock_logger.call_args[0][0]
+
+
+def test_verify_checksum_success(trivy_utils_instance):
+    """Test checksum verification with official checksums.txt"""
+    import hashlib
+    import tempfile
+    import shutil
+
+    mock_file_content = b"test binary content"
+    expected_hash = hashlib.sha256(mock_file_content).hexdigest()
+
+    mock_checksums = f"""f8766910f3909a75c603b7df630ff5639cf48d8eb0a2a26e4a20103a301e44f8 trivy_0.69.3_FreeBSD-64bit.tar.gz
+{expected_hash} trivy_0.69.3_Linux-64bit.tar.gz
+7e3924a974e912e57b4a99f65ece7931f8079584dae12eb7845024f97087bdfd trivy_0.69.3_Linux-ARM64.tar.gz
+"""
+
+    # Create temp dir and a file with exact expected name
+    tmp_dir = tempfile.mkdtemp()
+    tmp_path = os.path.join(tmp_dir, "trivy_0.69.3_Linux-64bit.tar.gz")
+    with open(tmp_path, "wb") as f:
+        f.write(mock_file_content)
+
+    try:
+        with patch("requests.get") as mock_get:
+            mock_response = Mock()
+            mock_response.text = mock_checksums
+            mock_response.status_code = 200
+            mock_response.raise_for_status = Mock()
+            mock_get.return_value = mock_response
+
+            result = trivy_utils_instance._verify_checksum(tmp_path)
+
+            assert result is True
+            mock_get.assert_called_once()
+            assert "checksums.txt" in mock_get.call_args[0][0]
+    finally:
+        shutil.rmtree(tmp_dir)
+
+
+def test_verify_checksum_mismatch(trivy_utils_instance):
+    """Test checksum detection of compromised"""
+    mock_checksums = """wronghash123 trivy_0.69.3_Linux-64bit.tar.gz
+"""
+
+    import tempfile
+    import shutil
+
+    # Create temp dir and a file with exact expected name
+    tmp_dir = tempfile.mkdtemp()
+    tmp_path = os.path.join(tmp_dir, "trivy_0.69.3_Linux-64bit.tar.gz")
+    with open(tmp_path, "wb") as f:
+        f.write(b"compromised content")
+
+    try:
+        with patch("requests.get") as mock_get, \
+             patch("devsecops_engine_tools.engine_utilities.trivy_utils.infrastructure.driven_adapters.trivy_manager_scan_utils.logger.error") as mock_logger:
+            mock_response = Mock()
+            mock_response.text = mock_checksums
+            mock_response.status_code = 200
+            mock_response.raise_for_status = Mock()
+            mock_get.return_value = mock_response
+
+            result = trivy_utils_instance._verify_checksum(tmp_path)
+
+            assert result is False
+            assert "CHECKSUM MISMATCH" in mock_logger.call_args[0][0]
+    finally:
+        shutil.rmtree(tmp_dir)
+
+
+def test_verify_checksum_no_checksums_file(trivy_utils_instance):
+    """Test graceful handling when checksums.txt doesn't exist"""
+    import tempfile
+    import shutil
+
+    # Create temp dir and a file with exact expected name
+    tmp_dir = tempfile.mkdtemp()
+    tmp_path = os.path.join(tmp_dir, "trivy_99.99.99_Linux-64bit.tar.gz")
+    with open(tmp_path, "wb") as f:
+        f.write(b"test content")
+
+    try:
+        with patch("requests.get") as mock_get, \
+             patch("devsecops_engine_tools.engine_utilities.trivy_utils.infrastructure.driven_adapters.trivy_manager_scan_utils.logger.warning") as mock_logger:
+            mock_response = Mock()
+            mock_response.status_code = 404
+            mock_get.return_value = mock_response
+
+            result = trivy_utils_instance._verify_checksum(tmp_path)
+
+            assert result is True  # Should allow when checksums unavailable
+            assert "No official checksums available" in mock_logger.call_args[0][0]
+    finally:
+        shutil.rmtree(tmp_dir)

--- a/tools/devsecops_engine_tools/engine_utilities/trivy_utils/infrastructure/driven_adapters/trivy_manager_scan_utils.py
+++ b/tools/devsecops_engine_tools/engine_utilities/trivy_utils/infrastructure/driven_adapters/trivy_manager_scan_utils.py
@@ -3,20 +3,37 @@ import platform
 import requests
 import tarfile
 import zipfile
+import hashlib
+import os
+import re
+import certifi
 from devsecops_engine_tools.engine_utilities.utils.logger_info import MyLogger
 from devsecops_engine_tools.engine_utilities import settings
 
 logger = MyLogger.__call__(**settings.SETTING_LOGGER).get_logger()
 
+# Explicitly blocked versions (supply chain attack CVE-2026-33634)
+BLOCKED_TRIVY_VERSIONS = {"0.69.4", "0.69.5", "0.69.6"}
+
+
 class TrivyManagerScanUtils():
     def identify_os_and_install(self, trivy_version):
+        # Security check: block compromised versions
+        if trivy_version in BLOCKED_TRIVY_VERSIONS:
+            logger.error(
+                f"TRIVY VERSION BLOCKED: v{trivy_version} is compromised (CVE-2026-33634). "
+                f"Please use a safe version (<=0.69.3 or >=0.70.1). "
+                f"See: https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23"
+            )
+            return None
+
         os_platform = platform.system()
         arch_platform = platform.architecture()[0]
         os_architecture = platform.machine()
         base_url = f"https://github.com/aquasecurity/trivy/releases/download/v{trivy_version}/"
 
         command_prefix = "trivy"
-        
+
         if os_platform == "Linux":
             if os_architecture == "aarch64":
                 file = f"trivy_{trivy_version}_Linux-ARM64.tar.gz"
@@ -46,15 +63,19 @@ class TrivyManagerScanUtils():
         )
         if installed.returncode == 1:
             try:
-                self._download_tool(file, url)
+                # Download and verify integrity
+                if not self._download_and_verify(file, url):
+                    return None
+
+                # Extract and install
                 with tarfile.open(file, 'r:gz') as tar_file:
                     tar_file.extract(member=tar_file.getmember("trivy"))
-                    return "./trivy"
+                    return self._make_executable("trivy")
             except Exception as e:
                 logger.error(f"Error installing trivy: {e}")
         else:
             return installed.stdout.decode().strip()
-        
+
     def _install_tool_windows(self, file, url, command_prefix):
         try:
             subprocess.run(
@@ -65,20 +86,153 @@ class TrivyManagerScanUtils():
             return command_prefix
         except:
             try:
-                self._download_tool(file, url)
+                # Download and verify integrity
+                if not self._download_and_verify(file, url):
+                    return None
+
+                # Extract and install
                 with zipfile.ZipFile(file, 'r') as zip_file:
                     zip_file.extract(member="trivy.exe")
-                    return "./trivy.exe"
+                    return os.path.abspath("trivy.exe")
             except Exception as e:
                 logger.error(f"Error installing trivy: {e}")
-    
+
+    def _download_and_verify(self, file, url):
+        """Download tool and verify SHA256 checksum. Returns True if successful."""
+        self._download_tool(file, url)
+
+        if not self._verify_checksum(file):
+            logger.error(
+                f"Checksum verification failed for {file}. "
+                f"The downloaded file may have been compromised. "
+                f"Please verify the SHA256 checksum manually from: "
+                f"https://github.com/aquasecurity/trivy/releases"
+            )
+            self._cleanup_file(file)
+            return False
+
+        return True
+
+    def _cleanup_file(self, file_path):
+        """Safely remove a downloaded file if it exists."""
+        try:
+            if os.path.exists(file_path):
+                os.remove(file_path)
+        except OSError as e:
+            logger.warning(f"Failed to cleanup file {file_path}: {e}")
+
+    def _make_executable(self, filename):
+        """Set executable permissions and return absolute path."""
+        abs_path = os.path.abspath(filename)
+        os.chmod(abs_path, 0o755)
+        return abs_path
+
+    def _verify_checksum(self, file_path):
+        """
+        Verify SHA256 checksum by downloading official checksums.txt from Trivy releases.
+        Returns True if checksum matches or if verification is not possible.
+        Returns False if checksum doesn't match.
+        """
+        try:
+            # Extract version from filename (e.g., "trivy_0.69.3_Linux-64bit.tar.gz")
+            match = re.search(r'trivy_(\d+\.\d+\.\d+)', file_path)
+            if not match:
+                logger.warning(f"Could not extract version from filename: {file_path}")
+                return True
+
+            version = match.group(1)
+            filename = os.path.basename(file_path)
+
+            # Download official checksums.txt from Trivy releases
+            checksums_url = f"https://github.com/aquasecurity/trivy/releases/download/v{version}/trivy_{version}_checksums.txt"
+            logger.info(f"Downloading official checksums from: {checksums_url}")
+
+            response = requests.get(
+                checksums_url,
+                allow_redirects=True,
+                verify=certifi.where(),
+                timeout=30
+            )
+
+            if response.status_code == 404:
+                logger.warning(
+                    f"No official checksums available for Trivy v{version}. "
+                    f"Skipping verification. Please manually verify from: "
+                    f"https://github.com/aquasecurity/trivy/releases"
+                )
+                return True
+
+            response.raise_for_status()
+
+            # Parse checksums.txt to find expected hash for this file
+            expected_checksum = None
+            for line in response.text.splitlines():
+                parts = line.strip().split()
+                if len(parts) == 2 and parts[1] == filename:
+                    expected_checksum = parts[0].lower()
+                    break
+
+            if not expected_checksum:
+                logger.warning(
+                    f"No checksum found for file: {filename} in official checksums.txt. "
+                    f"Skipping verification."
+                )
+                return True
+
+            # Calculate SHA256 checksum of downloaded file
+            sha256_hash = hashlib.sha256()
+            with open(file_path, "rb") as f:
+                for byte_block in iter(lambda: f.read(4096), b""):
+                    sha256_hash.update(byte_block)
+            actual_checksum = sha256_hash.hexdigest()
+
+            # Compare checksums
+            if actual_checksum != expected_checksum:
+                logger.error(
+                    f"CHECKSUM MISMATCH for {file_path}!\n"
+                    f"Expected: {expected_checksum}\n"
+                    f"Actual:   {actual_checksum}\n"
+                    f"The file may have been compromised!"
+                )
+                return False
+
+            logger.info(f"Checksum verification passed for {file_path}")
+            return True
+
+        except requests.exceptions.RequestException as e:
+            logger.warning(
+                f"Failed to download checksums.txt: {e}. "
+                f"Skipping verification."
+            )
+            return True
+        except Exception as e:
+            logger.error(f"Error during checksum verification: {e}")
+            return True
+
     def _download_tool(self, file, url):
         try:
-            response = requests.get(url, allow_redirects=True)
+            # Use certifi's CA bundle for stricter TLS verification
+            response = requests.get(
+                url,
+                allow_redirects=True,
+                verify=certifi.where(),  # Use certifi's CA bundle
+                timeout=300  # 5 minutes timeout for large files
+            )
+            response.raise_for_status()  # Raise exception for HTTP errors
+
             with open(file, "wb") as compress_file:
                 compress_file.write(response.content)
+
+            logger.info(f"Successfully downloaded Trivy from {url}")
+        except requests.exceptions.SSLError as e:
+            logger.error(f"TLS/SSL verification failed when downloading Trivy: {e}")
+            raise
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Network error when downloading Trivy: {e}")
+            raise
         except Exception as e:
             logger.error(f"Error downloading trivy: {e}")
+            raise
 
     @staticmethod
     def get_cvss_v3_severity(cvss_score: str, severity: str) -> str:
@@ -97,7 +251,7 @@ class TrivyManagerScanUtils():
                 return "high"
             elif cvss_score >= 9.0:
                 return "critical"
-    
+
     @staticmethod
     def get_cvss_v3_score(cvss_data: any) -> str:
         if not cvss_data:


### PR DESCRIPTION
## Description

This change improves the security and robustness of the Trivy binary download process by introducing checksum verification, blocking compromised versions, and enforcing stricter validation mechanisms.

It addresses the risk introduced by **CVE-2026-33634**, ensuring that only trusted and verified binaries are used. Additionally, the refactor removes duplicated logic and standardizes configuration handling.

Key updates include:

* Dynamic retrieval of `checksums.txt` instead of relying on hardcoded hashes
* Explicit blocking of compromised versions: `0.69.4`, `0.69.5`, `0.69.6`
* SHA256 checksum validation for downloaded binaries
* Strict TLS verification using `certifi` CA bundle
* Use of absolute paths to prevent PATH injection attacks
* Refactoring of download and verification logic into reusable methods (DRY)
* Standardization of `TRIVY_VERSION` config key (`CLI_VERSION` deprecated but still supported)
* Default version updated to `0.69.3` (last known safe version)
* Cleanup and categorization of `.gitignore`
* Unit tests updated to reflect new logic and configuration

### Fix

To fix the issue:

* Ensure Trivy binaries are always validated against official SHA256 checksums
* Prevent execution of known compromised versions by enforcing version blocking
* Use secure TLS verification when downloading artifacts
* Refactor the codebase to centralize and reuse download + verification logic
* Update configuration usage to rely on `TRIVY_VERSION`

At runtime, the system will:

* Reject unsafe versions automatically
* Fail if checksum validation does not pass
* Only allow secure downloads using trusted certificates

## Checklist:

* [X] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
* [X] I have performed a self-review of my own code
* [X] I have commented my code, particularly in hard-to-understand areas
* [X] I have made corresponding changes to the documentation
* [X] I have added tests that prove my feature, policy, or fix is effective and works
* [X] New and existing tests pass locally with my changes