### PR TITLE
fix: print traceback in engine_core

### DIFF
--- a/tools/devsecops_engine_tools/engine_core/src/applications/runner_engine_core.py
+++ b/tools/devsecops_engine_tools/engine_core/src/applications/runner_engine_core.py
@@ -311,7 +311,7 @@ def get_inputs_from_cli(args):
 
 
 def application_core():
-    tb = False
+    tb = True
     try:
         # Get inputs from CLI
         args = get_inputs_from_cli(sys.argv[1:])


### PR DESCRIPTION
## Description

print traceback in engine_core by default if fails before defines tb value

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
