### PR TITLE
feat(engine_iac): map Checkov download-external-modules flag from remote config

### DIFF
--- a/docs/Docusaurus/docs/modules/engine_sast/engine_iac.md
+++ b/docs/Docusaurus/docs/modules/engine_sast/engine_iac.md
@@ -53,6 +53,7 @@ Main configuration file that defines scanning behavior, tool versions, and secur
     "EXTERNAL_DIR_REPOSITORY": "",
     "APP_ID_GITHUB": "",
     "INSTALLATION_ID_GITHUB": "",
+    "DOWNLOAD_EXTERNAL_MODULES": false,
     "DEFAULT_SEVERITY": "Critical",
     "DEFAULT_CATEGORY": "Compliance",
     "REGEX_CLEAN_RESOURCE": "",
@@ -215,6 +216,8 @@ Main configuration file that defines scanning behavior, tool versions, and secur
 - **GitHub Integration**:
   - `APP_ID_GITHUB`: GitHub App ID for authentication
   - `INSTALLATION_ID_GITHUB`: GitHub App installation ID
+- **Module Download Behavior**:
+  - `DOWNLOAD_EXTERNAL_MODULES`: Enables/disables Checkov external module downloads during scan execution
 - **Default Values**:
   - `DEFAULT_SEVERITY`: Default severity level for new rules (`"Critical"`)
   - `DEFAULT_CATEGORY`: Default category for new rules (`"Compliance"`)
@@ -354,6 +357,32 @@ devsecops-engine-tools \
 2. Include all required fields: `checkID`, `environment`, `guideline`, `severity`, `category`
 3. Set environment-specific enablement flags (`dev`, `pdn`, `qa`)
 4. Provide documentation guidelines URL
+
+### Checkov Runtime Mapping: `DOWNLOAD_EXTERNAL_MODULES`
+
+Engine IAC now maps the remote config key `CHECKOV.DOWNLOAD_EXTERNAL_MODULES` into the Checkov runtime configuration.
+
+- **What changed**: The generated Checkov runtime config includes the `--download-external-modules` behavior based on remote config.
+- **Why it matters**: Scanner behavior can now be controlled from `ConfigTool.json` without requiring local code changes.
+
+Set this key in `ConfigTool.json`:
+
+```json
+"CHECKOV": {
+  "DOWNLOAD_EXTERNAL_MODULES": false
+}
+```
+
+Behavior:
+
+- `DOWNLOAD_EXTERNAL_MODULES: true`: Enables downloading external modules during Checkov scan execution.
+- `DOWNLOAD_EXTERNAL_MODULES: false`: Disables downloading external modules during Checkov scan execution.
+
+Implementation notes:
+
+1. Add support for `download-external-modules` in the Checkov config model and serialization.
+2. Map `CHECKOV.DOWNLOAD_EXTERNAL_MODULES` when building Checkov execution config in the adapter.
+3. Include `DOWNLOAD_EXTERNAL_MODULES` in the engine_iac local remote config contract.
 
 ### Managing Exclusions
 1. Add exclusions to `Exclusions.json` with proper expiration dates

--- a/example_remote_config_local/engine_sast/engine_iac/ConfigTool.json
+++ b/example_remote_config_local/engine_sast/engine_iac/ConfigTool.json
@@ -40,6 +40,7 @@
         "EXTERNAL_DIR_REPOSITORY": "",
         "APP_ID_GITHUB":"",
         "INSTALLATION_ID_GITHUB":"",
+        "DOWNLOAD_EXTERNAL_MODULES": false,
         "DEFAULT_SEVERITY": "Critical",
         "DEFAULT_CATEGORY": "Compliance",
         "SERVERLESS_ADITIONAL_CHECKS": ["RULES_CLOUDFORMATION"],

--- a/tools/devsecops_engine_tools/engine_sast/engine_iac/src/infrastructure/driven_adapters/checkov/checkov_config.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_iac/src/infrastructure/driven_adapters/checkov/checkov_config.py
@@ -24,6 +24,7 @@ class CheckovConfigEnum(Enum):
     SKIP_DOWNLOAD = "skip-download"
     REPO_ROOT_FOR_PLAN_ENRICHMENT = "repo-root-for-plan-enrichment"
     DEEP_ANALYSIS = "deep-analysis"
+    DOWNLOAD_EXTERNAL_MODULES = "download-external-modules"
 
 class CheckovConfig:
     dict_confg_file = {}
@@ -47,7 +48,8 @@ class CheckovConfig:
         skip_checks=None,
         skip_download=True,
         repo_root_for_plan_enrichment=None,
-        deep_analysis=None
+        deep_analysis=None,
+        download_external_modules=False,
     ):
         self.path_config_file = path_config_file
         self.config_file_name = config_file_name
@@ -67,6 +69,7 @@ class CheckovConfig:
         self.env = env
         self.repo_root_for_plan_enrichment = repo_root_for_plan_enrichment
         self.deep_analysis = deep_analysis
+        self.download_external_modules = download_external_modules
 
     def create_config_dict(self):
         if self.framework is not None:
@@ -150,5 +153,10 @@ class CheckovConfig:
             self.dict_confg_file[
                 CheckovConfigEnum.SKIP_DOWNLOAD.value
             ] = self.skip_download
+
+        if self.download_external_modules is not None:
+            self.dict_confg_file[
+                CheckovConfigEnum.DOWNLOAD_EXTERNAL_MODULES.value
+            ] = self.download_external_modules
 
         return self.dict_confg_file

--- a/tools/devsecops_engine_tools/engine_sast/engine_iac/src/infrastructure/driven_adapters/checkov/checkov_tool.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_iac/src/infrastructure/driven_adapters/checkov/checkov_tool.py
@@ -359,6 +359,9 @@ class CheckovTool(ToolGateway):
                         ),
                         repo_root_for_plan_enrichment=repo_root,
                         deep_analysis=(True if repo_root else None),
+                        download_external_modules=config_tool[self.TOOL_CHECKOV].get(
+                            "DOWNLOAD_EXTERNAL_MODULES", False
+                        ),
                     )
 
                     checkov_config.create_config_dict()


### PR DESCRIPTION
## Description

This PR adds support in Engine IAC Checkov integration to map the Checkov flag --download-external-modules from remote config.

Previously, the generated Checkov config did not include this flag from remote configuration. This change wires the global key DOWNLOAD_EXTERNAL_MODULES from **ConfigTool.json** into the Checkov runtime config, so the scanner behavior can be controlled directly from remote config without local code changes.

### Fix
To fix in code/runtime

Add support for download-external-modules in Checkov config model and serialization.
Map CHECKOV.DOWNLOAD_EXTERNAL_MODULES from remote config when building Checkov execution config in the adapter.
Add DOWNLOAD_EXTERNAL_MODULES in the local example remote config contract for engine_iac.

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
