### PR TITLE
fix: conftest deserializator node info

### DIFF
--- a/tools/devsecops_engine_tools/engine_sast/engine_iac/src/infrastructure/driven_adapters/conftest/conftest_deserealizator.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_iac/src/infrastructure/driven_adapters/conftest/conftest_deserealizator.py
@@ -26,9 +26,9 @@ class ConftestDeserealizator:
                 msg = failure.get("msg", "unknown")
                 metadata = failure.get("metadata", {}) or {}
                 query = metadata.get("query", "unknown")
-                node_type = metadata.get("node_type", "unknown")
-                node_id = metadata.get("node_id", "unknown")
-                where = f"{filename}: {node_type}.{node_id}"
+                node_type = metadata.get("node_type")
+                node_id = metadata.get("node_id")
+                where = f"{filename}: {node_type}.{node_id}" if node_type and node_id else filename
 
                 rule_id = metadata.get("id", "")
                 rule_meta = rules_lookup.get(rule_id, {})

--- a/tools/devsecops_engine_tools/engine_sast/engine_iac/test/infrastructure/driven_adapters/conftest/test_conftest_deserealizator.py
+++ b/tools/devsecops_engine_tools/engine_sast/engine_iac/test/infrastructure/driven_adapters/conftest/test_conftest_deserealizator.py
@@ -37,7 +37,7 @@ class TestConftestDeserealizator(unittest.TestCase):
         finding = findings[0]
         self.assertEqual(finding.id, "data.main.deny")  # no metadata.id → fallback to query
         self.assertEqual(finding.description, "Containers must not run as root")
-        self.assertEqual(finding.where, "deploy.yaml: unknown.unknown")
+        self.assertEqual(finding.where, "deploy.yaml")
         self.assertEqual(finding.severity, "high")
         self.assertEqual(finding.category, Category.VULNERABILITY)
         self.assertEqual(finding.tool, "Conftest")


### PR DESCRIPTION
### Fix
shows only filename when there is node type and id

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
