### PR TITLE
fix: adjust trivy risk acceptance matching for engine container

### DIFF
--- a/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/defect_dojo/defect_dojo.py
+++ b/tools/devsecops_engine_tools/engine_core/src/infrastructure/driven_adapters/defect_dojo/defect_dojo.py
@@ -904,6 +904,13 @@ class DefectDojoPlatform(VulnerabilityManagementGateway):
             else None
         )
 
+    def _extract_package_name(self, component_name):
+        prefix, separator, suffix = component_name.rpartition("_")
+        # only unwrap Maven-style "groupId_artifactId" (dotted groupId), keep other ecosystems intact
+        if separator and "." in prefix:
+            return suffix
+        return component_name
+
     def _get_where(self, finding, tool):
         if tool == "engine_dependencies":
             return (
@@ -912,7 +919,11 @@ class DefectDojoPlatform(VulnerabilityManagementGateway):
                 + finding.component_version
             )
         elif tool == "engine_container":
-            return finding.component_name + ":" + finding.component_version
+            return (
+                self._extract_package_name(finding.component_name)
+                + ":"
+                + finding.component_version
+            )
         elif tool == "engine_dast":
             return finding.endpoints
         elif tool == "engine_risk":

--- a/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/defect_dojo/test_defect_dojo.py
+++ b/tools/devsecops_engine_tools/engine_core/test/infrastructure/driven_adapters/defect_dojo/test_defect_dojo.py
@@ -1337,6 +1337,42 @@ class TestDefectDojoPlatform(unittest.TestCase):
         self.assertEqual(create_date, "default_date")
         self.assertEqual(expired_date, "default_date")
 
+    def test_get_where_engine_container_maven_component(self):
+        finding = MagicMock()
+        finding.component_name = "org.apache.logging.log4j_log4j-api"
+        finding.component_version = "2.23.1"
+
+        where = self.defect_dojo._get_where(finding, "engine_container")
+
+        self.assertEqual(where, "log4j-api:2.23.1")
+
+    def test_get_where_engine_container_non_maven_underscore(self):
+        finding = MagicMock()
+        finding.component_name = "typing_extensions"
+        finding.component_version = "4.9.0"
+
+        where = self.defect_dojo._get_where(finding, "engine_container")
+
+        self.assertEqual(where, "typing_extensions:4.9.0")
+
+    def test_get_where_engine_container_os_package(self):
+        finding = MagicMock()
+        finding.component_name = "libc6"
+        finding.component_version = "2.35"
+
+        where = self.defect_dojo._get_where(finding, "engine_container")
+
+        self.assertEqual(where, "libc6:2.35")
+
+    def test_get_where_engine_dependencies_unaffected(self):
+        finding = MagicMock()
+        finding.component_name = "org.apache.logging.log4j_log4j-api"
+        finding.component_version = "2.23.1"
+
+        where = self.defect_dojo._get_where(finding, "engine_dependencies")
+
+        self.assertEqual(where, "org.apache.logging.log4j:log4j-api:2.23.1")
+
     
     @patch(
         "devsecops_engine_tools.engine_core.src.infrastructure.driven_adapters.defect_dojo.defect_dojo.FindingExclusion.get_finding_exclusion"


### PR DESCRIPTION
## Description

*Fixes risk acceptance matching for engine_container findings reported by Trivy. 
DefectDojo stores Maven components as: org.apache.logging.log4j_log4j-api:2.23.1. Trivy reports them as: log4j-api:2.23.1

The mismatch prevented accepted findings from being excluded, causing the pipeline to fail.*

### Fix
*Added Maven artifact-name normalization in defect_dojo.py for engine_container.*

## Checklist:

- [x] The pull request is complete according to the guide of [contributing](https://github.com/bancolombia/devsecops-engine-tools/blob/trunk/docs/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature, policy, or fix is effective and works
- [x] New and existing tests pass locally with my changes
